### PR TITLE
NAS-130141 / 24.10 / remove `midclt sql` command

### DIFF
--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -596,8 +596,6 @@ def main():
     iparser.add_argument('method', nargs='+')
     subparsers.add_parser('ping', help='Ping')
     subparsers.add_parser('waitready', help='Wait server')
-    iparser = subparsers.add_parser('sql', help='Run SQL command')
-    iparser.add_argument('sql', nargs='+')
     iparser = subparsers.add_parser('subscribe', help='Subscribe to event')
     iparser.add_argument('event')
     iparser.add_argument('-n', '--number', type=int, help='Number of events to wait before exit')
@@ -680,29 +678,11 @@ def main():
         except (FileNotFoundError, ConnectionRefusedError):
             print('Failed to run middleware call. Daemon not running?', file=sys.stderr)
             sys.exit(1)
+
     elif args.name == 'ping':
         with Client(uri=args.uri) as c:
             if not c.ping():
                 sys.exit(1)
-    elif args.name == 'sql':
-        with Client(uri=args.uri) as c:
-            try:
-                if args.username and args.password:
-                    if not c.call('auth.login', args.username, args.password):
-                        raise ValueError('Invalid username or password')
-            except Exception as e:
-                print("Failed to login: ", e)
-                sys.exit(0)
-            rv = c.call('datastore.sql', args.sql[0])
-            if rv:
-                for i in rv:
-                    data = []
-                    for f in i:
-                        if isinstance(f, bool):
-                            data.append(str(int(f)))
-                        else:
-                            data.append(str(f))
-                    print('|'.join(data))
 
     elif args.name == 'subscribe':
         with Client(uri=args.uri) as c:

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -678,12 +678,10 @@ def main():
         except (FileNotFoundError, ConnectionRefusedError):
             print('Failed to run middleware call. Daemon not running?', file=sys.stderr)
             sys.exit(1)
-
     elif args.name == 'ping':
         with Client(uri=args.uri) as c:
             if not c.ping():
                 sys.exit(1)
-
     elif args.name == 'subscribe':
         with Client(uri=args.uri) as c:
 


### PR DESCRIPTION
The `midclt sql` command is obsoleted by being able to perform nearly all of the same operations through API calls. This is how we want the client to interact with middleware going forward rather than manually manipulating and viewing database tables.

Removing this command is easy since it is not used anywhere internally. Note that a near replacement of `midclt sql <query>` for now is `midclt call datastore.sql <query>`.