### PR TITLE
NAS-130565 / 25.04 / `midclt call -j` flag fix

### DIFF
--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -585,7 +585,7 @@ def main():
     subparsers = parser.add_subparsers(help='sub-command help', dest='name')
     iparser = subparsers.add_parser('call', help='Call method')
     iparser.add_argument(
-        '-j', '--job', help='Call a long running job', type=bool, default=False
+        '-j', '--job', help='Call a long running job', action='store_true'
     )
     iparser.add_argument(
         '-jp', '--job-print',


### PR DESCRIPTION
The current syntax to start a job via `midclt` is `midclt call -j <JOB> <method> <args ...>` where `JOB` is `False` by default. This syntax is confusing because `JOB` is an unnecessary argument--it is ignored (even passing "False" will evaluate as `True`). Instead, `-j` should be a flag like `-v` so that whenever present in the command, it will run as a job, i.e. `midclt call -j <method> <args ...>` (or `--job`).

Note: Presently, the common usage internally is `midclt call -job <method> <args ...>`. The "ob" after the "-j" is being passed as the `JOB` argument and being evaluated as `True` which is why this works.

Another note: 8 files in middleware will need to be updated with the new usage.