### PR TITLE
NAS-130179 / 24.10 / Handle error unpickling call exception

### DIFF
--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -334,11 +334,11 @@ class Client:
                     call.trace = message['error'].get('trace')
                     call.type = message['error'].get('type')
                     call.extra = message['error'].get('extra')
-                    call.py_exception = message['error'].get('py_exception')
-                    if self._py_exceptions and call.py_exception:
-                        call.py_exception = pickle.loads(b64decode(
-                            call.py_exception
-                        ))
+                    if self._py_exceptions and (py_exception := message['error'].get('py_exception')):
+                        try:
+                            call.py_exception = pickle.loads(b64decode(py_exception))
+                        except Exception as e:
+                            logger.warning("Error unpickling call exception: %r", e)
                 call.returned.set()
                 self._unregister_call(call)
             else:


### PR DESCRIPTION
The true error message is (as we can now see through the logs):
```
WARNING  truenas_api_client:__init__.py:341 Error unpickling call exception: ModuleNotFoundError("No module named 'middlewared.utils'")
```
This failure lead to `returned` flag not being set which was perceived as call failure