### PR TITLE
NAS-130887 / 25.04 / Remove `typing.NotRequired` for Python 3.10 compatibility

### DIFF
--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.10
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -1,4 +1,4 @@
-name: "pytype"
+name: 'pytype'
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
 
     - name: Install Dependencies
       run: |

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     install_requires=[
         "websocket-client",
     ],
+    python_requires=">=3.10",
     entry_points={
         "console_scripts": [
             "midclt = truenas_api_client:main",

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -385,12 +385,10 @@ class _Payload(_PartialPayload, total=False):
         event: `Event` that is set when the subscription should end.
         error: Information included in the Notification if the subscription ended in error.
         id: Random UUID assigned by `core.subscribe`.
-        ready: For backwards compatibility with `LegacyClient`.
 
     """
     error: str | TruenasError | None
     id: str
-    ready: Event
 
 
 class JSONRPCClient:

--- a/truenas_api_client/jsonrpc.py
+++ b/truenas_api_client/jsonrpc.py
@@ -4,7 +4,7 @@ https://www.jsonrpc.org/specification
 
 """
 import enum
-from typing import Any, Literal, NamedTuple, NotRequired, TypeAlias, TypedDict
+from typing import Any, Literal, NamedTuple, TypeAlias, TypedDict
 
 
 class JSONRPCError(enum.Enum):
@@ -49,9 +49,9 @@ class JobFields(TypedDict):
 class CollectionUpdateParams(TypedDict):
     msg: str
     collection: str
-    id: NotRequired[Any]
-    fields: NotRequired[JobFields]
-    extra: NotRequired[dict]
+    id: Any
+    fields: JobFields
+    extra: dict
 
 
 class CollectionUpdate(TypedDict):
@@ -62,7 +62,7 @@ class CollectionUpdate(TypedDict):
 
 TruenasTraceback = TypedDict('TruenasTraceback', {
     'class': str,
-    'frames': NotRequired[list[dict[str, Any]]],
+    'frames': list[dict[str, Any]],
     'formatted': str,
     'repr': str,
 })
@@ -75,7 +75,7 @@ class TruenasError(TypedDict):
     reason: str
     trace: TruenasTraceback | None
     extra: list[ErrorExtra]
-    py_exception: NotRequired[str]
+    py_exception: str
 
 
 class NotifyUnsubscribedParams(TypedDict):

--- a/truenas_api_client/legacy.py
+++ b/truenas_api_client/legacy.py
@@ -182,6 +182,7 @@ class Job:
                 job['error'],
                 trace={
                     'class': job['exc_info']['type'],
+                    'frames': [],
                     'formatted': job['exception'],
                     'repr': job['exc_info'].get('repr', job['exception'].splitlines()[-1]),
                 },


### PR DESCRIPTION
Though `typing.NotRequired` is useful when working with `TypedDict`, it wasn't introduced until Python 3.11. For the time being, we want to allow users to use the websocket client with Python 3.10.

This PR also changes setup.py to enforce a Python version >=3.10 in order to install the client.