### PR TITLE
Only allow py_exceptions to be used for unix domain sockets

### DIFF
--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -62,6 +62,10 @@ from .utils import MIDDLEWARE_RUN_DIR, ProgressBar, undefined, UndefinedType
 logger = logging.getLogger(__name__)
 
 
+UNIX_SOCKET_PREFIX = "ws+unix://"
+DUMMY_HOSTNAME = "ws://localhost/api/current"  # Advised by official docs to use dummy hostname
+
+
 class Client:
     """Implicit wrapper of either a `JSONRPCClient` or a `LegacyClient`."""
 
@@ -133,11 +137,10 @@ class WSClient:
             Exception: The `socket` failed to connect.
 
         """
-        unix_socket_prefix = "ws+unix://"
-        if self.url.startswith(unix_socket_prefix):
+        if self.url.startswith(UNIX_SOCKET_PREFIX):
             self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self.socket.connect(self.url.removeprefix(unix_socket_prefix))
-            app_url = "ws://localhost/api/current"  # Adviced by official docs to use dummy hostname
+            self.socket.connect(self.url.removeprefix(UNIX_SOCKET_PREFIX))
+            app_url = DUMMY_HOSTNAME
         elif self.reserved_ports:
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.settimeout(10)
@@ -148,7 +151,7 @@ class WSClient:
             except Exception:
                 self.socket.close()
                 raise
-            app_url = "ws://localhost/api/current"  # Adviced by official docs to use dummy hostname
+            app_url = DUMMY_HOSTNAME
         else:
             sockopt = sock_opt(None, None if self.verify_ssl else {"cert_reqs": ssl.CERT_NONE})
             sockopt.timeout = 10
@@ -216,7 +219,7 @@ class WSClient:
 
         """
         # TCP keepalive settings don't apply to local unix sockets
-        if 'ws+unix' not in self.url:
+        if UNIX_SOCKET_PREFIX not in self.url:
             # enable keepalives on the socket
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
 
@@ -416,10 +419,15 @@ class JSONRPCClient:
 
         """
         if uri is None:
-            uri = f'ws+unix://{MIDDLEWARE_RUN_DIR}/middlewared.sock'
+            uri = f'{UNIX_SOCKET_PREFIX}{MIDDLEWARE_RUN_DIR}/middlewared.sock'
 
         if call_timeout is undefined:
             call_timeout = CALL_TIMEOUT
+
+        # We pickle_load when handling py_exceptions, reduce risk of MITM on client causing a pickle.load
+        # of malicious information by only allowing this over unix domain socket.
+        if py_exceptions and not uri.startswith(UNIX_SOCKET_PREFIX):
+            raise ClientException('py_exceptions are only allowed for connections to unix domain socket')
 
         self._calls: dict[str, Call] = {}
         self._jobs: defaultdict[str, _JobDict] = defaultdict(dict)  # type: ignore


### PR DESCRIPTION
Avoid pickle.loads of response from remote servers.