### PR TITLE
NAS-133037 / 25.04 / make api_client work on macos

### DIFF
--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -58,7 +58,7 @@ from .config import CALL_TIMEOUT
 from .exc import ReserveFDException, ClientException, ErrnoMixin, ValidationErrors, CallTimeout
 from .legacy import LegacyClient
 from .jsonrpc import CollectionUpdateParams, ErrorObj, JobFields, JSONRPCError, JSONRPCMessage, TruenasError
-from .utils import MIDDLEWARE_RUN_DIR, ProgressBar, undefined, UndefinedType
+from .utils import MIDDLEWARE_RUN_DIR, ProgressBar, undefined, UndefinedType, set_socket_options
 
 logger = logging.getLogger(__name__)
 
@@ -218,21 +218,7 @@ class WSClient:
         """
         # TCP keepalive settings don't apply to local unix sockets
         if 'ws+unix' not in self.url:
-            # enable keepalives on the socket
-            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-
-            # If the other node panics then the socket will
-            # remain open and we'll have to wait until the
-            # TCP timeout value expires (60 seconds default).
-            # To account for this:
-            #   1. if the socket is idle for 1 seconds
-            #   2. send a keepalive packet every 1 second
-            #   3. for a maximum up to 5 times
-            #
-            # after 5 times (5 seconds of no response), the socket will be closed
-            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 1)
-            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 1)
-            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5)
+            set_socket_options(self.socket)
 
         # if we're able to connect put socket in blocking mode
         # until all operations complete or error is raised

--- a/truenas_api_client/utils.py
+++ b/truenas_api_client/utils.py
@@ -136,7 +136,7 @@ class ProgressBar(object):
 
 def set_socket_options(socobj):
     plat = sys.platform
-    if plat not in ('linux', 'freebsd', 'darwin'):
+    if plat not in ('win32', 'linux', 'freebsd', 'darwin'):
         raise RuntimeError('Unsupported platform')
 
     # enable keepalives on the socket
@@ -151,10 +151,11 @@ def set_socket_options(socobj):
     #   3. for a maximum up to 5 times
     #
     # after 5 times (5 seconds of no response), the socket will be closed
-    if plat in ('linux', 'freebsd'):
-        socobj.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 1)
+    if plat in ('linux', 'freebsd', 'win32'):
+        socobj.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 1)  # pytype: disable=module-attr
+
     else:
-        socobj.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 1)
+        socobj.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 1)  # pytype: disable=module-attr
 
     socobj.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 1)
     socobj.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5)


### PR DESCRIPTION
As pointed out in https://github.com/truenas/api_client/issues/13, running this on macOS crashes with `AttributeError` because they have different socket options. This adds a helper function to prevent that from occurring.