### PR TITLE
Add trivial example of creating SMB share using API

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+<p align="center">
+      <a href="https://discord.gg/Q3St5fPETd"><img alt="Join Discord" src="https://badgen.net/discord/members/Q3St5fPETd/?icon=discord&label=Join%20the%20TrueNAS%20Community" /></a>
+ <a href="https://www.truenas.com/community/"><img alt="Join Forums" src="https://badgen.net/badge/Forums/Post%20Now//purple" /></a> 
+ <a href="https://jira.ixsystems.com"><img alt="File Issue" src="https://badgen.net/badge/Jira/File%20Issue//red?icon=jira" /></a>
+</p>
+
+# TrueNAS Websocket Client Examples
+
+*Found an issue? Please report it on our [Jira bugtracker](https://jira.ixsystems.com).*
+
+## About
+
+This directory contains various code snippets to provide examples of how a developer may use the TrueNAS websocket client.
+
+## Contents
+
+* `create_smb_timemachine_share.py` - this script provides a very basic example of how to create a new ZFS dataset
+  and share that can be used as a MacOS time machine target.
+
+## Helpful Links
+
+<a href="https://truenas.com">
+<img align="right" src="https://www.truenas.com/docs/images/TrueNAS_Open_Enterprise_Storage.png" />
+</a>
+
+- [Websocket API docs](https://www.truenas.com/docs/api/scale_websocket_api.html)
+- [Middleware repo](https://github.com/truenas/middleware)
+- [Official TrueNAS Documentation Hub](https://www.truenas.com/docs/)
+- [Get started building TrueNAS Scale](https://github.com/truenas/scale-build)
+- [Forums](https://www.truenas.com/community/)

--- a/examples/create_smb_time_machine_share.py
+++ b/examples/create_smb_time_machine_share.py
@@ -6,7 +6,7 @@ API_USERNAME = "api_user"
 API_KEY = "some api key"
 
 
-with Client("wss://example.internal") as c:
+with Client("wss://example.internal/api/current") as c:
     # Authenticate using some pre-existing API key
     resp = c.call("auth.login_ex", {
         "mechanism": "API_KEY_PLAIN",

--- a/examples/create_smb_time_machine_share.py
+++ b/examples/create_smb_time_machine_share.py
@@ -1,0 +1,31 @@
+from truenas_api_client import Client
+
+DS_NAME = "dozer/test_smb_share"
+SHARE_NAME = "SHARE"
+API_USERNAME = "api_user"
+API_KEY = "some api key"
+
+
+with Client("wss://example.internal") as c:
+    # Authenticate using some pre-existing API key
+    resp = c.call("auth.login_ex", {
+        "mechanism": "API_KEY_PLAIN",
+        "username": API_USERNAME,
+        "api_key": API_KEY
+    })
+    assert resp["response_type"] == "SUCCESS"
+
+    # Check whether we've been configured as an OSX server
+    smb_config = c.call("smb.config")
+    if not smb_config["aapl_extensions"]:
+        c.call("smb.update", {"aapl_extensions": True})
+
+    # Create SMB-style dataset with basic open permissions
+    ds = c.call("pool.dataset.create", {"name": DS_NAME, "share_type": "SMB"})
+
+    # Create the actual SMB share for time machine purposes
+    c.call("sharing.smb.create", {
+        "path": ds["mountpoint"],
+        "name": SHARE_NAME,
+        "purpose": "TIMEMACHINE"
+    })


### PR DESCRIPTION
This commit adds an examples dir for the repo for developers to give API documentation a little more relevant context.