### PR TITLE
Warn when -j used unnecessarily

### DIFF
--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -785,10 +785,13 @@ class JSONRPCClient:
                     raise c.error
 
             if job:
-                jobobj = Job(self, c.result, callback=callback)
-                if job == 'RETURN':
-                    return jobobj
-                return jobobj.result()
+                if isinstance(c.result, int):
+                    jobobj = Job(self, c.result, callback=callback)
+                    if job == 'RETURN':
+                        return jobobj
+                    return jobobj.result()
+                else:
+                    print('WARNING: Call did not return a job ID. Is the method a job?', file=sys.stderr)
 
             return c.result
         finally:

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -785,7 +785,7 @@ class JSONRPCClient:
                     raise c.error
 
             if job:
-                if isinstance(c.result, int):
+                if c.result in self._jobs:
                     jobobj = Job(self, c.result, callback=callback)
                     if job == 'RETURN':
                         return jobobj


### PR DESCRIPTION
Sometimes the user mistakenly passes the `-j` flag to call a job when the method does not represent a job. We should handle this cleanly by recognizing the result is not a job ID and handling the call as if `-j` had not been passed while warning the user.