### PR TITLE
NAS-137733 / 26.04 / fix truenas_api_client build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: iX Engineering <dev@ixsystems.net>
 Build-Depends: debhelper-compat (= 12),
                dh-python,
+               pybuild-plugin-pyproject,
                python3-all,
                python3-setuptools,
                python3-websocket (>= 1.3.2)


### PR DESCRIPTION
Forgot to add this as a dependency so Debian package is failing to build without it.