### PR TITLE
NAS-137916 / 25.10.0 / Error can be null on unsubscribe notification (by creatorcary)

### DIFF
--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -520,7 +520,8 @@ class JSONRPCClient:
                         if params['collection'] in self._event_callbacks:
                             for event in self._event_callbacks[params['collection']]:
                                 if 'error' in params:
-                                    event['error'] = params['error']['reason'] or params['error']
+                                    err = params['error']
+                                    event['error'] = reason if err and (reason := err['reason']) else err
                                 event['event'].set()
                     case _:
                         logger.error('Received unknown notification %r', message['method'])

--- a/truenas_api_client/jsonrpc.py
+++ b/truenas_api_client/jsonrpc.py
@@ -80,7 +80,7 @@ class TruenasError(TypedDict):
 
 class NotifyUnsubscribedParams(TypedDict):
     collection: str
-    error: TruenasError
+    error: TruenasError | None
 
 
 class NotifyUnsubscribed(TypedDict):


### PR DESCRIPTION
The client crashes on receiving notification of a successful unsubscribe operation.

```
root@testA32KUUM6FC[~]# midclt subscribe 'filesystem.file_tail_follow:{"path": ""}'
Unhandled exception in JSONRPCClient._recv
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/truenas_api_client/__init__.py", line 523, in _recv
    event['error'] = params['error']['reason'] or params['error']
                     ~~~~~~~~~~~~~~~^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

null should be expected as a possible value for the "error" field as shown by this method in middleware:
https://github.com/truenas/middleware/blob/c8b76381a848ec09c515607e401f85feabfb2f60/src/middlewared/middlewared/api/base/server/ws_handler/rpc.py#L200

Fails on latest GE

Original PR: https://github.com/truenas/api_client/pull/45
