### PR TITLE
NAS-139772 / 26.0.0-BETA.1 / Add stdin processing for midclt

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ root@my_truenas[~]# midclt --uri ws://some.other.truenas/api/current -U user -P 
 root@my_truenas[~]# midclt call -j pool.dataset.lock mypool/mydataset
 ```
 
+#### Use API key from file and read payload from stdin
+
+The `-K` option accepts either a raw API key string or a path to a file containing the key. You can also use `-` to read
+the API call payload from stdin (via pipe or input redirection), which is useful for keeping sensitive data out of
+command history and process listings.
+
+```bash
+# API key from file, payload from stdin via input redirection
+midclt -U larry -K /home/larry/truenas_api_key.json call user.create - < /home/larry/user_secret_payload.json
+
+# API key from file, payload from stdin via pipe
+cat /path/to/secret/payload.json | midclt -U admin -K /root/.truenas_api_key call user.create -
+```
+
 ### Scripting
 
 The TrueNAS API client can also be used in Python scripts.

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -1056,11 +1056,25 @@ def main():
         args.password = getpass()
 
     def from_json(args):
+        stdin_content = None
         for i in args:
-            try:
-                yield json.loads(i)
-            except Exception:
-                yield i
+            if i == '-':
+                # Read from stdin once and cache it
+                if stdin_content is None:
+                    if sys.stdin.isatty():
+                        print("Error: Cannot read from stdin when connected to a terminal.", file=sys.stderr)
+                        print("Please pipe input or provide the argument directly.", file=sys.stderr)
+                        sys.exit(1)
+                    stdin_content = sys.stdin.read()
+                try:
+                    yield json.loads(stdin_content)
+                except Exception:
+                    yield stdin_content
+            else:
+                try:
+                    yield json.loads(i)
+                except Exception:
+                    yield i
 
     if args.name == 'call':
         try:


### PR DESCRIPTION
This commit adds a variant of argument parsing for midclt commands to avoid having users follow bad online guidance to write scripts containing secrets and pass as arguments to midclt commands directly (or just run command from terminal).

```
root@testK6DDHJBE20-nodea[~/api_client]# echo '{"username": "awalker", "full_name": "awalker", "group_create": true, "password": "TOPSECRET"}' > payload.json
root@testK6DDHJBE20-nodea[~/api_client]# midclt call user.create - < payload.json
```