### PR TITLE
NAS-139781 / 26.0.0-BETA.1 / Add ability to specify username with api_key

### DIFF
--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -1052,7 +1052,7 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
-    if args.username and not args.password:
+    if args.username and not args.password and not args.api_key:
         args.password = getpass()
 
     def from_json(args):


### PR DESCRIPTION
Since TrueNAS 25.04 API keys have been linked to particular user accounts rather than being system-wide. Currently if you try to specify a username with an API key you are prompted for a password. This commit fixes the logic so that you are prompted for password only if username specified without api key or password.