### PR TITLE
NAS-139797 / 26.0.0-BETA.1 / Update code example for new API key helper

### DIFF
--- a/examples/create_smb_time_machine_share.py
+++ b/examples/create_smb_time_machine_share.py
@@ -3,17 +3,13 @@ from truenas_api_client import Client
 DS_NAME = "dozer/test_smb_share"
 SHARE_NAME = "SHARE"
 API_USERNAME = "api_user"
-API_KEY = "some api key"
+API_KEY_FILE = "/path/to/api_key.json"  # Can also be a raw key string
 
 
 with Client("wss://example.internal/api/current") as c:
-    # Authenticate using some pre-existing API key
-    resp = c.call("auth.login_ex", {
-        "mechanism": "API_KEY_PLAIN",
-        "username": API_USERNAME,
-        "api_key": API_KEY
-    })
-    assert resp["response_type"] == "SUCCESS"
+    # Authenticate using API key (automatically uses SCRAM-SHA512 if available)
+    # API_KEY_FILE can be either a file path or the raw key string
+    c.login_with_api_key(API_USERNAME, API_KEY_FILE)
 
     # Check whether we've been configured as an OSX server
     smb_config = c.call("smb.config")


### PR DESCRIPTION
This commit updates a code example for creating a time machine share to show best-practice involving API keys.