### PR TITLE
NAS-140695 / 27.0.0-BETA.1 / api_client: add ability to specify OTP and legacy support

### DIFF
--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -996,7 +996,7 @@ class JSONRPCClient:
         """
         api_key_authenticate(self, auth_mechanism, username, api_key)
 
-    def login_with_password(self, username: str, password: str) -> None:
+    def login_with_password(self, username: str, password: str, *, otp_token: str | None = None) -> None:
         """
         Authenticate via username and password.
 
@@ -1006,6 +1006,7 @@ class JSONRPCClient:
         Args:
             username: account username
             password: account password
+            otp_token: one-time password token for two-factor authentication
 
         Raises:
             ValueError: authentication failed or OTP required
@@ -1019,7 +1020,7 @@ class JSONRPCClient:
         except ClientException as exc:
             if exc.error == 'Method does not exist':
                 # Pre-25.04 server
-                if not self.call('auth.login', username, password):
+                if not self.call('auth.login', username, password, otp_token):
                     raise ValueError('Invalid username or password')
                 return
             raise
@@ -1028,10 +1029,17 @@ class JSONRPCClient:
             case 'SUCCESS':
                 return
             case 'OTP_REQUIRED':
-                raise ValueError(
-                    'Two-factor authentication is required for this account. '
-                    'Use auth.login_ex and auth.login_ex_continue for OTP flow.'
-                )
+                if otp_token is None:
+                    raise ValueError(
+                        'Two-factor authentication is required for this account. '
+                        'Call login_with_password again with otp_token specified.'
+                    )
+                otp_resp = self.call('auth.login_ex', {
+                    'mechanism': 'OTP_TOKEN',
+                    'otp_token': otp_token,
+                })
+                if otp_resp['response_type'] != 'SUCCESS':
+                    raise ValueError('Invalid one-time password token')
             case _:
                 raise ValueError('Invalid username or password')
 

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -1009,7 +1009,7 @@ class JSONRPCClient:
             otp_token: one-time password token for two-factor authentication
 
         Raises:
-            ValueError: authentication failed or OTP required
+            ValueError: authentication failed, invalid OTP, or OTP required but not provided
         """
         try:
             resp = self.call('auth.login_ex', {
@@ -1034,7 +1034,7 @@ class JSONRPCClient:
                         'Two-factor authentication is required for this account. '
                         'Call login_with_password again with otp_token specified.'
                     )
-                otp_resp = self.call('auth.login_ex', {
+                otp_resp = self.call('auth.login_ex_continue', {
                     'mechanism': 'OTP_TOKEN',
                     'otp_token': otp_token,
                 })

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -1009,7 +1009,8 @@ class JSONRPCClient:
             otp_token: one-time password token for two-factor authentication
 
         Raises:
-            ValueError: authentication failed, invalid OTP, or OTP required but not provided
+            ValueError: authentication failed, invalid OTP, OTP required but not provided,
+                account credentials expired, account lacks API access, or redirect required
         """
         try:
             resp = self.call('auth.login_ex', {
@@ -1025,6 +1026,9 @@ class JSONRPCClient:
                 return
             raise
 
+        self._handle_login_ex_response(resp, otp_token)
+
+    def _handle_login_ex_response(self, resp: dict, otp_token: str | None) -> None:
         match resp['response_type']:
             case 'SUCCESS':
                 return
@@ -1038,8 +1042,17 @@ class JSONRPCClient:
                     'mechanism': 'OTP_TOKEN',
                     'otp_token': otp_token,
                 })
-                if otp_resp['response_type'] != 'SUCCESS':
-                    raise ValueError('Invalid one-time password token')
+                self._handle_login_ex_response(otp_resp, None)
+            case 'REDIRECT':
+                urls = ', '.join(resp.get('urls', []))
+                raise ValueError(
+                    f'Authentication must be performed on active storage controller. '
+                    f'Redirect URLs: {urls}'
+                )
+            case 'EXPIRED':
+                raise ValueError('Account credentials have expired')
+            case 'DENIED':
+                raise ValueError('Account does not have API access')
             case _:
                 raise ValueError('Invalid username or password')
 

--- a/truenas_api_client/legacy.py
+++ b/truenas_api_client/legacy.py
@@ -20,6 +20,7 @@ from websocket._http import connect, proxy_info
 from websocket._socket import sock_opt
 
 from . import ejson as json
+from .auth_api_key import APIKeyAuthMech, api_key_authenticate
 from .config import CALL_TIMEOUT
 from .exc import ReserveFDException, ClientException, ValidationErrors, CallTimeout
 from .utils import MIDDLEWARE_RUN_DIR, undefined, UndefinedType, set_socket_options
@@ -483,6 +484,48 @@ class LegacyClient:
         if not event.wait(timeout):
             return False
         return True
+
+    def login_with_api_key(
+        self,
+        username: str,
+        api_key: str,
+        auth_mechanism: APIKeyAuthMech = APIKeyAuthMech.AUTO
+    ) -> None:
+        """
+        Helper function to authenticate via API key to the truenas server.
+
+        Args:
+            username: name of the user that the API key is associated with
+                NOTE: this is required for SCRAM authentication
+            api_key: either the key material or an absolute path to the file where it is stored
+            auth_mechanism: one of "AUTO", "SCRAM", "PLAIN" specifying the type of authentication
+                to perform. AUTO will use SCRAM if support for it is detected.
+
+        Returns:
+            None
+
+        Raises:
+            ValueError: an error occurred during authentication.
+        """
+        api_key_authenticate(self, auth_mechanism, username, api_key)
+
+    def login_with_password(self, username: str, password: str, *, otp_token: str | None = None) -> None:
+        """
+        Authenticate via username and password.
+
+        Uses auth.login which accepts an optional otp_token for
+        two-factor authentication.
+
+        Args:
+            username: account username
+            password: account password
+            otp_token: one-time password token for two-factor authentication
+
+        Raises:
+            ValueError: authentication failed
+        """
+        if not self.call('auth.login', username, password, otp_token):
+            raise ValueError('Invalid username or password')
 
     def close(self):
         self._ws.close()

--- a/truenas_api_client/legacy.py
+++ b/truenas_api_client/legacy.py
@@ -489,17 +489,20 @@ class LegacyClient:
         self,
         username: str,
         api_key: str,
-        auth_mechanism: APIKeyAuthMech = APIKeyAuthMech.AUTO
+        auth_mechanism: APIKeyAuthMech = APIKeyAuthMech.PLAIN
     ) -> None:
         """
-        Helper function to authenticate via API key to the truenas server.
+        Helper function to authenticate via API key to the truenas server. Legacy TrueNAS servers
+        had a significantly different API key implementation. They were de-facto linked to the root
+        account with a per-key server-side allowlist defined that declared what middleware methods
+        were authorized for the key.
 
         Args:
-            username: name of the user that the API key is associated with
-                NOTE: this is required for SCRAM authentication
+            username: this parameter is ignored for legacy clients. It exists to ensure consistent
+               function signatures for API consumers.
             api_key: either the key material or an absolute path to the file where it is stored
-            auth_mechanism: one of "AUTO", "SCRAM", "PLAIN" specifying the type of authentication
-                to perform. AUTO will use SCRAM if support for it is detected.
+            auth_mechanism: one of "AUTO", "PLAIN" specifying the type of authentication. A ValueError
+               will be raised if SCRAM is specified.
 
         Returns:
             None
@@ -507,6 +510,9 @@ class LegacyClient:
         Raises:
             ValueError: an error occurred during authentication.
         """
+        if auth_mechanism == APIKeyAuthMech.SCRAM:
+            raise ValueError('Legacy TrueNAS servers do not implement SCRAM authentication')
+
         api_key_authenticate(self, auth_mechanism, username, api_key)
 
     def login_with_password(self, username: str, password: str, *, otp_token: str | None = None) -> None:


### PR DESCRIPTION
This commit add the ability to specify an OTP token programmatically, which is used in our keychain credentials code in middleware as well as adding our authentication helper methods for the legacy API client so that they are available when connecting to really old truenas servers (for example truenas 13).