### PR TITLE
NAS-141466 / 26.0.0-RC.1 / api_client: add SCRAM-PLUS channel binding (by anodos325)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,6 +31,8 @@ jobs:
         apt install -y python3-pip python3-setuptools python3-build libidn-dev
         apt install -y python3-argparse-manpage
         apt install -y python3-websocket
+        # python3-cryptography: test-only oracle for the channel-binding conformance tests
+        apt install -y python3-cryptography
 
     - name: Build truenas_scram Debian packages
       run: |

--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ with Client(uri="ws://some.other.truenas/api/current") as c:
       c.login_with_api_key(username, "/path/to/keyfile.json")
 ```
 
+#### Channel binding (SCRAM-PLUS)
+
+When SCRAM API-key authentication runs over a TLS (`wss://`) connection, `login_with_api_key`
+binds the exchange to the server's certificate (SCRAM-PLUS, RFC 5929 `tls-server-end-point`),
+which lets the server detect a TLS-terminating man-in-the-middle. This is the **default**, and
+authentication fails if the binding cannot be negotiated — for example over a non-TLS network
+connection (`ws://`), or against a server that does not support channel binding. The local
+middleware UNIX socket is exempt. SCRAM API-key authentication and channel binding are both
+supported on TrueNAS 26 and later. Binding works even with `verify_ssl=False`, since the
+certificate is still read from the TLS handshake.
+
+Pass `channel_binding=False` to authenticate without it:
+
+```python
+# Reach a server without channel-binding support, or a plain ws:// endpoint
+with Client(uri="wss://some.other.truenas/api/current") as c:
+      c.login_with_api_key(username, key, channel_binding=False)
+```
+
+The `midclt` CLI exposes the same override as `--no-channel-binding`.
+
 ### API Key Storage Formats
 
 TrueNAS API keys can be stored in multiple formats. The key material is provided by TrueNAS when generating an

--- a/README.md
+++ b/README.md
@@ -156,6 +156,22 @@ with Client(uri="ws://some.other.truenas/api/current") as c:
       c.login_with_api_key(username, "/path/to/keyfile.json")
 ```
 
+API-key login uses **SCRAM-SHA-512** by default (TrueNAS 26 and later), which never transmits
+the key over the wire. To reach a server that does not support SCRAM (TrueNAS before 26) you
+must opt in to plaintext authentication explicitly — the client never auto-downgrades, because
+the server's advertised mechanism list is unauthenticated and a man-in-the-middle could
+otherwise strip SCRAM to force the client to divulge the cleartext key:
+
+```python
+from truenas_api_client import APIKeyAuthMech
+
+with Client(uri="ws://old.truenas/api/current") as c:
+      c.login_with_api_key(username, key, auth_mechanism=APIKeyAuthMech.PLAIN)
+```
+
+The `midclt` CLI exposes this as `--plain`. **Warning:** PLAIN transmits the raw API key; only
+the TLS layer (if any) protects it.
+
 #### Channel binding (SCRAM-PLUS)
 
 When SCRAM API-key authentication runs over a TLS (`wss://`) connection, `login_with_api_key`
@@ -180,8 +196,8 @@ The `midclt` CLI exposes the same override as `--no-channel-binding`.
 ### API Key Storage Formats
 
 TrueNAS API keys can be stored in multiple formats. The key material is provided by TrueNAS when generating an
-API key. SCRAM-SHA512 authentication is supported in TrueNAS version 26 and later. Earlier versions use plain API key
-authentication.
+API key. SCRAM-SHA512 authentication is supported in TrueNAS version 26 and later. Reaching earlier versions
+requires explicitly opting in to plain API key authentication (`auth_mechanism=APIKeyAuthMech.PLAIN` / `midclt --plain`).
 
 #### Raw API Key
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,12 @@ license = {text = "LGPLv3"}
 dynamic = ["version"]
 dependencies = ["websocket-client"]
 
+[project.optional-dependencies]
+# Test-only: python-cryptography is used purely as an independent oracle in the
+# channel-binding conformance tests (tests/scram/). It is NOT a runtime dependency
+# -- the py_scram fallback parser is pure-stdlib.
+test = ["cryptography"]
+
 [project.scripts]
 midclt = "truenas_api_client:main"
 

--- a/tests/scram/_cb_test_vectors.py
+++ b/tests/scram/_cb_test_vectors.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Auto-generated channel-binding parity/promotion test vectors.
+
+Each entry is (name, certificate_DER, expected tls-server-end-point). These cover
+signature algorithms beyond the default RSA-PKCS1/SHA-256: RSASSA-PSS (whose digest
+lives in the signature parameters), DSA, ECDSA-SHA384, and SHA-1 (promoted to
+SHA-256 per RFC 5929 4.1). py_scram and truenas_pyscram both equal `expected`.
+"""
+from base64 import b64decode
+
+CB_VECTORS = [
+    ("rsa_pss_sha256", b64decode(
+        "MIIDezCCAi+gAwIBAgIUbvFLoNTxKxJMSKWyAwDtovtPfIwwQQYJKoZIhvcNAQEKMDSgDzAN"
+        "BglghkgBZQMEAgEFAKEcMBoGCSqGSIb3DQEBCDANBglghkgBZQMEAgEFAKIDAgEgMBkxFzAV"
+        "BgNVBAMMDnJzYV9wc3Nfc2hhMjU2MB4XDTI2MDYyMjIwNTkzNloXDTM2MDYxOTIwNTkzNlow"
+        "GTEXMBUGA1UEAwwOcnNhX3Bzc19zaGEyNTYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK"
+        "AoIBAQDpa19BgN87rCwx3j+OkZN2JvpBcM7OQF3O0otYaHePBaGuMYNBApo0PqBp9E1oakm7"
+        "ZktqSVpANOp/G4b4+VNIEEi2AO8AUU+hJgw1t2xlLzzxlynstRVVaB3RqYhSdC4HJaBeCC5O"
+        "fZ9c14qjzIj6jQANpO/bb2N2aPr5uwSViLiV3MXvN8+g5pXzlSbdRPJyqJdvLgXHA/tS3axR"
+        "DHb6P/loIhrE8yaWMJvY1wpp856+WwOu8mVSTwMv0mhScZnJ5BtF3UJJyPjIY8B/VSK189Sj"
+        "PidhhXZNk8+1QaHCe4RwuFnMUybGoOmcTBaXJPDErfwt6pGD0ZcjXnW7myUFAgMBAAGjUzBR"
+        "MB0GA1UdDgQWBBTuhQOK9oKQhMFCzFx+tYgScnTgHDAfBgNVHSMEGDAWgBTuhQOK9oKQhMFC"
+        "zFx+tYgScnTgHDAPBgNVHRMBAf8EBTADAQH/MEEGCSqGSIb3DQEBCjA0oA8wDQYJYIZIAWUD"
+        "BAIBBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAIBBQCiAwIBIAOCAQEAob7QddtJ12v7"
+        "b5RNPSzEP+2GD+1nUGQkOa1lfBzTP0jzvO2f/fgiybKCvZtk/u+PV5fnRsHShgXvhDPzWwzX"
+        "BJG6BZ1D/jWfyodoiAOM8RPvA73hIRxtgCtCxGjcC8z2DJi0/GOxNo7RvtGkRwo4JDeG30nA"
+        "4UIe8/m2QkO+fHNqBeCUWfi8VGqbXELoGSkL3gWNVHYDWh269GpZBpIu7fw48tuoGxPm7QOV"
+        "E2VTAhbvJp3TlFU46ykyp3XdFlGG4+06e5E31/KoFOZH98l3fSw8P4USGoHnUos7XtqnGkTl"
+        "Xseuk0DCagMSMiSDsik9pQ9dAk46rg5yZAEzZehC5g=="
+    ), bytes.fromhex(
+        "a0de0778a5718d214b015d441510876b5b5731bbd622edce1e85be4ad740b250"
+    )),
+    ("rsa_pss_sha512", b64decode(
+        "MIIDezCCAi+gAwIBAgIUI4DhlL/djqOWQrT2Djf/oCZZuP4wQQYJKoZIhvcNAQEKMDSgDzAN"
+        "BglghkgBZQMEAgMFAKEcMBoGCSqGSIb3DQEBCDANBglghkgBZQMEAgMFAKIDAgFAMBkxFzAV"
+        "BgNVBAMMDnJzYV9wc3Nfc2hhNTEyMB4XDTI2MDYyMjIwNTkzNloXDTM2MDYxOTIwNTkzNlow"
+        "GTEXMBUGA1UEAwwOcnNhX3Bzc19zaGE1MTIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK"
+        "AoIBAQCvn0EEVFvC+1YpBcs9pshNI/3RQueSeG4TrOOccthZWQSpal7nuXNgjYHuRcnASykr"
+        "0QUcdkNnWkrejILE0o3yHNc3jrEFGkVW2nhuG6rRTcRmqzCL9CQ4n5DH3tyilnwLDZXZ0Xdu"
+        "xcMPnj8QR45pZIfMxY7x8BXItTjfTFR3Ym7a+zeGLGwj+xYsPeOGlCPO7TsPaYySM8ZyS4ak"
+        "PN39A3xMHJuH8d3hIDm0oNBA78hqxF0tx8UK8UY2KPOucehwIQYZ9HFyWo5NxbX23a3mfXe6"
+        "MHoOD+6y1nD80YFStK8aUlU6JrrcDDnVO7QzPGnx6njc0HAlYM3V/XuvHny5AgMBAAGjUzBR"
+        "MB0GA1UdDgQWBBSbk4AXUwNJhOrmzv9NMmq5CIeWPDAfBgNVHSMEGDAWgBSbk4AXUwNJhOrm"
+        "zv9NMmq5CIeWPDAPBgNVHRMBAf8EBTADAQH/MEEGCSqGSIb3DQEBCjA0oA8wDQYJYIZIAWUD"
+        "BAIDBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAIDBQCiAwIBQAOCAQEAR1emzB16GHIL"
+        "xWiTq7kAirHxYlh80phTMRv0AarLDNavW0ZptncQlh2EeyzsUEknokIjqvpL9r+NrLWa+iIr"
+        "+3J8ZaWiiBLdGEmENebMnM1OGnCQB9yBwneyoLEFZiPNFDM6S2/uSbyM0ir1P95zi51MYBAE"
+        "pQ3YWjAtXB1CgrIjOJ2b08CkJVy3uyKk7CiDRmDXFsM6pVC0cI4yso9a8/wrhxmO4Evq2v8o"
+        "hXyduSqu1BNUTg3NvDGwwlU9Uik/hp5iV/P47mhONfv+hZP/cCdnCNzJT2V7dB3+h7wQUBmC"
+        "UKWiFtC03S7iR8d2+Pxrd9WShBydRU8gHDqjG1ZwHw=="
+    ), bytes.fromhex(
+        "4b2eb9c0b129e10c0a09b29a4d670062efd0da53be232a54b65b0c4a0f193e3a"
+        "133d79cb8f569681e3bc131dae654bd5f8a34b7215a18d42bae6343313bdabe8"
+    )),
+    ("ecdsa_sha384", b64decode(
+        "MIIBwTCCAUagAwIBAgIUf+oUEWmBYwffug4hBlnRAtFdejQwCgYIKoZIzj0EAwMwFzEVMBMG"
+        "A1UEAwwMZWNkc2Ffc2hhMzg0MB4XDTI2MDYyMjIwNTkzNloXDTM2MDYxOTIwNTkzNlowFzEV"
+        "MBMGA1UEAwwMZWNkc2Ffc2hhMzg0MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQXRbllZNtIe8"
+        "nEqVC0Pnv9XrtYuK3JjTX8h8+sd5yZtXoKoXvTZA3s8oRyTp+Ua9Y/154OqiDufPBpiVJVa1"
+        "v28xiw9d2AiWa19VxyTQTTyrHofUnXb0VWWFQAi+UFMQo1MwUTAdBgNVHQ4EFgQUeRKlokr7"
+        "DgnFjJdRNzpPunHBb0MwHwYDVR0jBBgwFoAUeRKlokr7DgnFjJdRNzpPunHBb0MwDwYDVR0T"
+        "AQH/BAUwAwEB/zAKBggqhkjOPQQDAwNpADBmAjEA9/opjXvE22x675TqsjWogAbJJMe9tAJG"
+        "I7RoMiGWaRO3Jam06Ik64/nAXn7tDLP4AjEAryelYXb9DOOS6sanz4D+puRLU4CdiNlA89iT"
+        "WTjtkH7w+ctmj8jKXNBeLKdbrCEL"
+    ), bytes.fromhex(
+        "a16feae6f8a8e471fcd17c797a3d9357f3df17e16e3f2e30da1bb92d81723f7faebf9e29c7cdb73b4755e781e433d785"
+    )),
+    ("rsa_sha1", b64decode(
+        "MIIDBzCCAe+gAwIBAgIUPJQDMd+Kp0m5FxshY+PfE0Z47fIwDQYJKoZIhvcNAQEFBQAwEzER"
+        "MA8GA1UEAwwIcnNhX3NoYTEwHhcNMjYwNjIyMjA1OTM2WhcNMzYwNjE5MjA1OTM2WjATMREw"
+        "DwYDVQQDDAhyc2Ffc2hhMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMkVoiEJ"
+        "x7ANcSzCThZSdu/oXYQf4bYpvFGH7xa+23l7Kbei9KBSCcB12HWSGeQb+bik9OU7fIC5DWMH"
+        "H0nolgNIwclebPORL+6tUYA+xxqIN0dXsjMcD7J9MR6KLX8YcwlnmCjPw9qOTRrmXiUsqWsE"
+        "jwytsqxuMvTMUnJG2gNJNLyuCabBWHVzPWXoVKBT7j6b93RSSl1Z4GhN7gpfLmSVQPaJ0Iw5"
+        "2hTOgj5pffPIKVx6Se4diS8Wp/9QReFO2tZW7ccFcwCUeml72CJlp8zgFanfuwdeVRJF1DEn"
+        "eKKo/egmONTWG074shpnFB1jdgqxXRXAcaztNZ2i0k+L3ZECAwEAAaNTMFEwHQYDVR0OBBYE"
+        "FHSiQey2fSDnEc20AkTScG71uDsHMB8GA1UdIwQYMBaAFHSiQey2fSDnEc20AkTScG71uDsH"
+        "MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAHI8I9RBh0FBX3Oi3U1vQCwC"
+        "JG2NrKiA73FoqohUxXVCq6JUojG8l484uJHw2P2zaUTaai1vdG+zKmwbX235uitxXtQ8oY9b"
+        "juIQjBsUwyikldSsZVE30EFmKUXIvhWDssvI6pU/t+jINuac1Ht/zMkz0aAzVrLwaAMrNbtU"
+        "DUaB4BMtGaC+TNMzALBYiD51dfPlRbDZKqc7l2zhXXyu+WoaIsK+pVqTA69aTdO0pYNBt34c"
+        "dq/lzuj/eU27A96MOIRMrGE4VB9yc1phkUfEWmSWNEglREOnYWMWm466z4E6jbAjb5zJGMev"
+        "iAvEGMy6pUKgTRW7FEVxvFtDUDjL5pw="
+    ), bytes.fromhex(
+        "9cf8083887b586b8aa1b511190141c824e73fd09eac93f0945c0199080023710"
+    )),
+    ("dsa_sha256", b64decode(
+        "MIIEZzCCBBOgAwIBAgIUZRfnSemmaQReHYhIXH/LT3EEQdgwCwYJYIZIAWUDBAMCMBUxEzAR"
+        "BgNVBAMMCmRzYV9zaGEyNTYwHhcNMjYwNjIyMjA1OTM2WhcNMzYwNjE5MjA1OTM2WjAVMRMw"
+        "EQYDVQQDDApkc2Ffc2hhMjU2MIIDRDCCAjYGByqGSM44BAEwggIpAoIBAQCJo/kAk+fYjTtW"
+        "oDagfPciNzvMIQnY/y+rBu+jzMMjPA0/gsSNlI1ixGYdSwMGee8ZpI+VIlK6FynXPJgeCVmJ"
+        "SxTVoXGT+AdSoWbhw7q9CDlqPeUb431rOplUL5O0pklZHVcznl7q3EvvhNLaJ1iMXDvE1nsm"
+        "LlnKxdQYdA7j69vgZCawyGMl6UwP5deox8/MLcdvgK49p4ryI43rzAS+17KhlftXKt+KZktI"
+        "RIdhacOimJZgfy6oELEh4z6FlF3SXGqv5tWpWlpnSKQcDDVXG9CRmcU16zNc9MkJTsrZcDMh"
+        "BGSkDW8jAK/bd6E9YuqZ9nB6gNN3d+XzhW5sN6gZAh0A41ap4k32+1Cj0CIMKLVFXWCd8562"
+        "FUZhRHuZIQKCAQEAiZ387IoEmYZX/8U5tR1aczxDkVcy8wgyOvhobXhj/aMD6q84KK6I2mlx"
+        "AyLxpC5sZBUiu7h+Mkftb0gqWZFwtQiczuawuQET0YhoqeuAOniGyZryZEGZeuG5BgTb9eaW"
+        "7a3D2fYm50hfFhFKSlnZAJR2ZNFZNaxOoYraeCSqVukbBwmLQgbr95YKPTX3puwzf5gY7I6e"
+        "u15mXgZpVcy5wrZ1pxRyLLYQPoCoI3bzOHoqgmnJmykWFzPObRWJiZlpkQLQ3O9T8LR6Wqmi"
+        "jhdWpYDcPchNbWVOq37Mpl7OrVottTy+pYoYjwM+j32hH5iequWDgdcw/cDpd+FH7i4LVgOC"
+        "AQYAAoIBAQCIc1x0JSROUVfeDr0nIbqgZIN6zMg7YCC9mJMdQcIiSahnSaHOJzRtGapcN6Ta"
+        "HfY3zApx53JMU81gwWzWYCJcWs2gbjaLHSlm3lDNyPTRgzuWWKvyvKHvL7TGRfNnOS/VrvzO"
+        "/hxA2w1fpTWBcn5tIJQk1ri2yWxUJUQ52/t7WojUgen14Bi2qeITvELmwXFnuSs8UhsRwal1"
+        "2fxMC/fdnh4jR8gBfvirlH0vvRB4ZrOIhU+ZwjwebZKNFdH9IJcvMcz3XnYA8FvP3R99VWkx"
+        "JubCeWVlNJZzUCs7L5C0+cPBPkPce9sOrS3iqHMpk4J62JjM/CEgSBJ3VDNvh3iXo1MwUTAd"
+        "BgNVHQ4EFgQUzVmJizDr+Rth2910JRdW45fV6XkwHwYDVR0jBBgwFoAUzVmJizDr+Rth2910"
+        "JRdW45fV6XkwDwYDVR0TAQH/BAUwAwEB/zALBglghkgBZQMEAwIDQQAwPgIdANTFiRLd6oV6"
+        "mknToIBJjTAp9csMwFRPsF+nS9ACHQC24O9iRcqXU+rta7ocM6SDhSiDn1KZapUIAqHU"
+    ), bytes.fromhex(
+        "6e19e230f917fd3922f39fff90a263f1df618fd4d8080037f75f1b32f97b0e27"
+    )),
+]
+
+# Signature algorithms with no single well-defined hash: rejected by both
+# py_scram and truenas_pyscram (RFC 5929 4.1 -> undefined).
+REJECTED_VECTORS = [
+    ("ed25519", b64decode(
+        "MIIBODCB66ADAgECAhRF/i2VZfabTYtGC96jEmDKQWs7HzAFBgMrZXAwEjEQMA4GA1UEAwwH"
+        "ZWQyNTUxOTAeFw0yNjA2MjIyMDU5MzZaFw0zNjA2MTkyMDU5MzZaMBIxEDAOBgNVBAMMB2Vk"
+        "MjU1MTkwKjAFBgMrZXADIQBG6mG6PIveRZbDEpUA0h2+zqcfkFflhjFU6WMltek8H6NTMFEw"
+        "HQYDVR0OBBYEFI0SqZaciNfleT/XktQEcIjga8GhMB8GA1UdIwQYMBaAFI0SqZaciNfleT/X"
+        "ktQEcIjga8GhMA8GA1UdEwEB/wQFMAMBAf8wBQYDK2VwA0EAMvh4cKf/RBo2Pa9xlyAI1PxL"
+        "R43eNEd6siuiayO5lojZy92QlmHI3Y1SEF7RQd6E9PeKsGmdo/Pcpu75xrfTDw=="
+    )),
+]

--- a/tests/scram/test_compatibility.py
+++ b/tests/scram/test_compatibility.py
@@ -15,7 +15,7 @@ import truenas_api_client.py_scram as py_scram
 try:
     from ._cb_test_vectors import CB_VECTORS, REJECTED_VECTORS
 except ImportError:  # direct execution: python3 tests/scram/test_compatibility.py
-    from _cb_test_vectors import CB_VECTORS, REJECTED_VECTORS
+    from _cb_test_vectors import CB_VECTORS, REJECTED_VECTORS  # type: ignore
 
 # Self-signed RSA-2048 / sha256WithRSAEncryption certificate (DER) for channel-binding
 # parity checks (tls-server-end-point == SHA-256(DER) for a SHA-256-signed cert).

--- a/tests/scram/test_compatibility.py
+++ b/tests/scram/test_compatibility.py
@@ -6,11 +6,33 @@ produces identical results to the C extension (truenas_pyscram).
 """
 
 import unittest
-from base64 import b64encode
+from base64 import b64decode, b64encode
 from ssl import RAND_bytes
 
 import truenas_pyscram  # type: ignore
 import truenas_api_client.py_scram as py_scram
+
+# Self-signed RSA-2048 / sha256WithRSAEncryption certificate (DER) for channel-binding
+# parity checks (tls-server-end-point == SHA-256(DER) for a SHA-256-signed cert).
+_CB_TEST_CERT_DER = b64decode(
+    "MIIDAzCCAeugAwIBAgIUU8DHCkgRz1ra3Hc0Hhdyypn/bq4wDQYJKoZIhvcNAQEL"
+    "BQAwETEPMA0GA1UEAwwGcnNhMjU2MB4XDTI2MDYxODE4NDAyMVoXDTI2MDYxOTE4"
+    "NDAyMVowETEPMA0GA1UEAwwGcnNhMjU2MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A"
+    "MIIBCgKCAQEAn3RdfzhUjYiv3rrVCxga+sKEF4TavdzRW0vBoAP+XFWMyDEEfLEL"
+    "V5z4sVGvs6vpbc9bRkgPlYbzjs3GDRtDjdJHV8SbLPQtG/M8wdCHuRbM8r2/H8vL"
+    "h4q+GNeZ14jzSQTvsRfbxNNoyZxRDPnYlqTCmPEhU7PojrJia8/088OaC0W92nOf"
+    "S7CDwdHKPOmjsBMefAWWRgfTO4PHVPhIvZ+BrQeTUsJRsiSNSYTCPA5LvjRPuvrN"
+    "VRjxggidHuoOTQuJVBr91mSsWN32ZqeEtWjPThsr1KXj+hpolYWCMoR/I64VypzA"
+    "LHnMZrYxwZIRrpF4x5pips1/8nh1J7/UpQIDAQABo1MwUTAdBgNVHQ4EFgQU4QBk"
+    "o+s6X7VIK1CVjb5Cx+VDo6owHwYDVR0jBBgwFoAU4QBko+s6X7VIK1CVjb5Cx+VD"
+    "o6owDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAlDfSQoKry1Og"
+    "XzY1JSRVWVIBC5Mevgt0rA0u6hlSNp+MC1p/KvN2Q25IWZznQfkPLtFvIEwBehsW"
+    "h7xQ+R3DDbr2rX1z6gUKLfS2GkEPUn51YBlwjeuBNkOTb4svonOlXF4cG04bJN62"
+    "NkgXz/U0Tyf4V7BEd82bxn/eChP34sTWb5AA2+iyp4MNkqk1j12gBKaxn7vtiXJn"
+    "XIIVXgOS2zezizp8zXrd39Hjd/qWdkZDv4hN/ZMnDuQ9HclYwtamL5Taf9YFKDBw"
+    "puLEOWIalVSCsq28yqvbPg31430JYH0dNWrpC93+Q9UU2UM30Ai6kp5pLo7b18DI"
+    "WnZ+wlB6zQ=="
+)
 
 
 class TestClientFirstMessageCompatibility(unittest.TestCase):
@@ -346,6 +368,71 @@ class TestVerificationFunctionCompatibility(unittest.TestCase):
             server_final=server_final,
             server_key=self.auth_data.server_key
         )
+
+
+class TestChannelBindingCompatibility(unittest.TestCase):
+    """Test tls-server-end-point channel binding parity between implementations."""
+
+    def test_compute_parity(self):
+        c = bytes(truenas_pyscram.compute_tls_server_end_point(_CB_TEST_CERT_DER))
+        p = bytes(py_scram.compute_tls_server_end_point(_CB_TEST_CERT_DER))
+        self.assertEqual(c, p)
+
+    def test_cb_name_constant_parity(self):
+        self.assertEqual(py_scram.CB_TLS_SERVER_END_POINT, truenas_pyscram.CB_TLS_SERVER_END_POINT)
+
+    def _build_py_bound_exchange(self, auth, binding):
+        py_cf = py_scram.ClientFirstMessage(
+            username="u", api_key_id=5,
+            channel_binding_type=py_scram.CB_TLS_SERVER_END_POINT,
+        )
+        py_sf = py_scram.ServerFirstMessage(
+            client_first=py_cf,
+            salt=py_scram.CryptoDatum(bytes(auth.salt)),
+            iterations=auth.iterations,
+        )
+        py_fin = py_scram.ClientFinalMessage(
+            client_first=py_cf, server_first=py_sf,
+            client_key=py_scram.CryptoDatum(bytes(auth.client_key)),
+            stored_key=py_scram.CryptoDatum(bytes(auth.stored_key)),
+            channel_binding=binding,
+        )
+        return py_cf, py_sf, py_fin
+
+    def test_py_bound_exchange_verified_by_c_extension(self):
+        """A fully py_scram-built channel-bound exchange is accepted by the C-ext server."""
+        auth = truenas_pyscram.generate_scram_auth_data()
+        binding = py_scram.compute_tls_server_end_point(_CB_TEST_CERT_DER)
+        py_cf, py_sf, py_fin = self._build_py_bound_exchange(auth, binding)
+
+        # c= must be base64("p=tls-server-end-point,," + binding).
+        c_attr = next(part[2:] for part in str(py_fin).split(",") if part.startswith("c="))
+        self.assertEqual(c_attr, b64encode(b"p=tls-server-end-point,," + bytes(binding)).decode())
+
+        # The C-extension server verifier accepts the py-built bound final.
+        truenas_pyscram.verify_client_final_message(
+            truenas_pyscram.ClientFirstMessage(rfc_string=str(py_cf)),
+            truenas_pyscram.ServerFirstMessage(rfc_string=str(py_sf)),
+            truenas_pyscram.ClientFinalMessage(rfc_string=str(py_fin)),
+            auth.stored_key,
+            channel_binding=truenas_pyscram.compute_tls_server_end_point(_CB_TEST_CERT_DER),
+            require_channel_binding=True,
+        )
+
+    def test_wrong_binding_rejected_by_c_extension(self):
+        auth = truenas_pyscram.generate_scram_auth_data()
+        binding = py_scram.compute_tls_server_end_point(_CB_TEST_CERT_DER)
+        py_cf, py_sf, py_fin = self._build_py_bound_exchange(auth, binding)
+
+        with self.assertRaises(Exception):
+            truenas_pyscram.verify_client_final_message(
+                truenas_pyscram.ClientFirstMessage(rfc_string=str(py_cf)),
+                truenas_pyscram.ServerFirstMessage(rfc_string=str(py_sf)),
+                truenas_pyscram.ClientFinalMessage(rfc_string=str(py_fin)),
+                auth.stored_key,
+                channel_binding=truenas_pyscram.CryptoDatum(b"\x00" * 32),
+                require_channel_binding=True,
+            )
 
 
 if __name__ == '__main__':

--- a/tests/scram/test_compatibility.py
+++ b/tests/scram/test_compatibility.py
@@ -12,6 +12,11 @@ from ssl import RAND_bytes
 import truenas_pyscram  # type: ignore
 import truenas_api_client.py_scram as py_scram
 
+try:
+    from ._cb_test_vectors import CB_VECTORS, REJECTED_VECTORS
+except ImportError:  # direct execution: python3 tests/scram/test_compatibility.py
+    from _cb_test_vectors import CB_VECTORS, REJECTED_VECTORS
+
 # Self-signed RSA-2048 / sha256WithRSAEncryption certificate (DER) for channel-binding
 # parity checks (tls-server-end-point == SHA-256(DER) for a SHA-256-signed cert).
 _CB_TEST_CERT_DER = b64decode(
@@ -377,6 +382,25 @@ class TestChannelBindingCompatibility(unittest.TestCase):
         c = bytes(truenas_pyscram.compute_tls_server_end_point(_CB_TEST_CERT_DER))
         p = bytes(py_scram.compute_tls_server_end_point(_CB_TEST_CERT_DER))
         self.assertEqual(c, p)
+
+    def test_signature_algorithm_parity(self):
+        """py_scram mirrors the C extension across RSA-PSS / DSA / ECDSA / SHA-1 promotion."""
+        for name, cert_der, expected in CB_VECTORS:
+            with self.subTest(cert=name):
+                p = bytes(py_scram.compute_tls_server_end_point(cert_der))
+                c = bytes(truenas_pyscram.compute_tls_server_end_point(cert_der))
+                self.assertEqual(p, expected, f'{name}: py_scram diverged')
+                self.assertEqual(c, expected, f'{name}: C extension diverged')
+
+    def test_undefined_signature_algorithm_rejected_by_both(self):
+        """EdDSA (no single signature hash) is rejected by py_scram and the C
+        extension alike -- the divergence-free boundary of the OID table."""
+        for name, cert_der in REJECTED_VECTORS:
+            with self.subTest(cert=name):
+                with self.assertRaises(ValueError):
+                    py_scram.compute_tls_server_end_point(cert_der)
+                with self.assertRaises(Exception):
+                    truenas_pyscram.compute_tls_server_end_point(cert_der)
 
     def test_cb_name_constant_parity(self):
         self.assertEqual(py_scram.CB_TLS_SERVER_END_POINT, truenas_pyscram.CB_TLS_SERVER_END_POINT)

--- a/tests/scram/test_py_scram.py
+++ b/tests/scram/test_py_scram.py
@@ -12,6 +12,19 @@ from base64 import b64decode, b64encode
 
 import truenas_api_client.py_scram as py_scram
 
+try:
+    from ._cb_test_vectors import CB_VECTORS, REJECTED_VECTORS
+except ImportError:  # direct execution: python3 tests/scram/test_py_scram.py
+    from _cb_test_vectors import CB_VECTORS, REJECTED_VECTORS
+
+try:
+    # Test-only oracle (not a runtime dependency of the client).
+    from cryptography import x509 as _x509
+    from cryptography.exceptions import UnsupportedAlgorithm as _CryptoUnsupported
+    _HAVE_CRYPTOGRAPHY = True
+except ImportError:
+    _HAVE_CRYPTOGRAPHY = False
+
 # Self-signed RSA-2048 / sha256WithRSAEncryption certificate (DER). Its RFC 5929
 # tls-server-end-point value equals SHA-256(DER) because the cert is SHA-256 signed.
 _CB_TEST_CERT_DER = b64decode(
@@ -83,6 +96,20 @@ class TestClientFirstMessage(unittest.TestCase):
         msg = py_scram.ClientFirstMessage(username="testuser", gs2_header="n")
 
         self.assertEqual(msg.gs2_header, "n")
+
+    def test_channel_binding_type_builds_p_flag(self):
+        """A channel_binding_type produces a 'p=<cb-name>,,' gs2 cbind flag."""
+        msg = py_scram.ClientFirstMessage(
+            username="testuser", channel_binding_type="tls-server-end-point")
+
+        self.assertEqual(msg.gs2_header, "p=tls-server-end-point")
+        self.assertTrue(str(msg).startswith("p=tls-server-end-point,,"))
+
+    def test_empty_channel_binding_type_rejected(self):
+        """An empty channel_binding_type would emit a malformed 'p=' header; it is
+        rejected, matching the C library's scram_build_gs2_header()."""
+        with self.assertRaises(ValueError):
+            py_scram.ClientFirstMessage(username="testuser", channel_binding_type="")
 
     def test_serialization(self):
         """Test ClientFirstMessage serialization."""
@@ -535,6 +562,29 @@ class TestChannelBinding(unittest.TestCase):
         with self.assertRaises(ValueError):
             py_scram.compute_tls_server_end_point(b"not a certificate")
 
+    def test_rejects_undefined_signature_algorithm(self):
+        """Signature algorithms with no single well-defined hash (e.g. EdDSA) are
+        rejected, matching the C library."""
+        for name, cert_der in REJECTED_VECTORS:
+            with self.subTest(cert=name):
+                with self.assertRaises(ValueError):
+                    py_scram.compute_tls_server_end_point(cert_der)
+
+    def test_signature_algorithm_hashes(self):
+        """Lock the OID->hash selection without the C ext: RSA-PSS (digest read from
+        the signature parameters), DSA, ECDSA-SHA384, and the SHA-1 -> SHA-256
+        promotion each yield the expected digest."""
+        expected_len = {
+            'rsa_pss_sha256': 32, 'rsa_pss_sha512': 64, 'ecdsa_sha384': 48,
+            'rsa_sha1': 32,  # SHA-1 promoted to SHA-256
+            'dsa_sha256': 32,
+        }
+        for name, cert_der, expected in CB_VECTORS:
+            with self.subTest(cert=name):
+                binding = py_scram.compute_tls_server_end_point(cert_der)
+                self.assertEqual(bytes(binding), expected)
+                self.assertEqual(len(bytes(binding)), expected_len[name])
+
 
 class TestChannelBindingServerSignatureRoundTrip(unittest.TestCase):
     """Regression test for the cbind-input reconstruction in verify_server_signature.
@@ -600,6 +650,51 @@ class TestChannelBindingServerSignatureRoundTrip(unittest.TestCase):
             client_first=cf, server_first=sf, client_final=fin,
             server_final=server_final, server_key=auth.server_key,
         )
+
+
+def _cryptography_tls_server_end_point(cert_der):
+    """Independent reference using python-cryptography: hash the certificate with the
+    digest from its own signature algorithm (MD5/SHA-1 promoted to SHA-256, RFC 5929
+    4.1), or raise ValueError when the algorithm defines no single hash (e.g. EdDSA)."""
+    cert = _x509.load_der_x509_certificate(bytes(cert_der))
+    try:
+        sig_hash = cert.signature_hash_algorithm
+    except _CryptoUnsupported:
+        sig_hash = None
+    if sig_hash is None:
+        raise ValueError('tls-server-end-point is undefined for this certificate')
+    name = sig_hash.name
+    if name in ('md5', 'sha1'):
+        name = 'sha256'
+    return hashlib.new(name, bytes(cert_der)).digest()
+
+
+@unittest.skipUnless(_HAVE_CRYPTOGRAPHY, 'python-cryptography not installed')
+class TestChannelBindingCryptographyConformance(unittest.TestCase):
+    """Cross-check the pure-python (fallback) channel-binding parser against an
+    independent python-cryptography reference -- a third oracle alongside the
+    truenas_pyscram C extension (test_compatibility.py) and the frozen vectors.
+
+    py_scram.compute_tls_server_end_point only runs when the C extension is absent,
+    so this guards a rarely-exercised path: it confirms the hand-rolled DER walk
+    selects the same signature digest cryptography's ASN.1 parser does.
+    """
+
+    def test_matches_cryptography(self):
+        for name, cert_der, _expected in CB_VECTORS:
+            with self.subTest(cert=name):
+                self.assertEqual(
+                    bytes(py_scram.compute_tls_server_end_point(cert_der)),
+                    _cryptography_tls_server_end_point(cert_der),
+                )
+
+    def test_rejection_agrees_with_cryptography(self):
+        for name, cert_der in REJECTED_VECTORS:
+            with self.subTest(cert=name):
+                with self.assertRaises(ValueError):
+                    py_scram.compute_tls_server_end_point(cert_der)
+                with self.assertRaises(ValueError):
+                    _cryptography_tls_server_end_point(cert_der)
 
 
 if __name__ == '__main__':

--- a/tests/scram/test_py_scram.py
+++ b/tests/scram/test_py_scram.py
@@ -15,12 +15,12 @@ import truenas_api_client.py_scram as py_scram
 try:
     from ._cb_test_vectors import CB_VECTORS, REJECTED_VECTORS
 except ImportError:  # direct execution: python3 tests/scram/test_py_scram.py
-    from _cb_test_vectors import CB_VECTORS, REJECTED_VECTORS
+    from _cb_test_vectors import CB_VECTORS, REJECTED_VECTORS  # type: ignore
 
 try:
     # Test-only oracle (not a runtime dependency of the client).
-    from cryptography import x509 as _x509
-    from cryptography.exceptions import UnsupportedAlgorithm as _CryptoUnsupported
+    from cryptography import x509 as _x509  # type: ignore
+    from cryptography.exceptions import UnsupportedAlgorithm as _CryptoUnsupported  # type: ignore
     _HAVE_CRYPTOGRAPHY = True
 except ImportError:
     _HAVE_CRYPTOGRAPHY = False

--- a/tests/scram/test_py_scram.py
+++ b/tests/scram/test_py_scram.py
@@ -5,9 +5,37 @@ This test suite validates the pure Python implementation works correctly
 independent of the C extension.
 """
 
+import hashlib
+import hmac
 import unittest
+from base64 import b64decode, b64encode
 
 import truenas_api_client.py_scram as py_scram
+
+# Self-signed RSA-2048 / sha256WithRSAEncryption certificate (DER). Its RFC 5929
+# tls-server-end-point value equals SHA-256(DER) because the cert is SHA-256 signed.
+_CB_TEST_CERT_DER = b64decode(
+    "MIIDAzCCAeugAwIBAgIUU8DHCkgRz1ra3Hc0Hhdyypn/bq4wDQYJKoZIhvcNAQEL"
+    "BQAwETEPMA0GA1UEAwwGcnNhMjU2MB4XDTI2MDYxODE4NDAyMVoXDTI2MDYxOTE4"
+    "NDAyMVowETEPMA0GA1UEAwwGcnNhMjU2MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A"
+    "MIIBCgKCAQEAn3RdfzhUjYiv3rrVCxga+sKEF4TavdzRW0vBoAP+XFWMyDEEfLEL"
+    "V5z4sVGvs6vpbc9bRkgPlYbzjs3GDRtDjdJHV8SbLPQtG/M8wdCHuRbM8r2/H8vL"
+    "h4q+GNeZ14jzSQTvsRfbxNNoyZxRDPnYlqTCmPEhU7PojrJia8/088OaC0W92nOf"
+    "S7CDwdHKPOmjsBMefAWWRgfTO4PHVPhIvZ+BrQeTUsJRsiSNSYTCPA5LvjRPuvrN"
+    "VRjxggidHuoOTQuJVBr91mSsWN32ZqeEtWjPThsr1KXj+hpolYWCMoR/I64VypzA"
+    "LHnMZrYxwZIRrpF4x5pips1/8nh1J7/UpQIDAQABo1MwUTAdBgNVHQ4EFgQU4QBk"
+    "o+s6X7VIK1CVjb5Cx+VDo6owHwYDVR0jBBgwFoAU4QBko+s6X7VIK1CVjb5Cx+VD"
+    "o6owDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAlDfSQoKry1Og"
+    "XzY1JSRVWVIBC5Mevgt0rA0u6hlSNp+MC1p/KvN2Q25IWZznQfkPLtFvIEwBehsW"
+    "h7xQ+R3DDbr2rX1z6gUKLfS2GkEPUn51YBlwjeuBNkOTb4svonOlXF4cG04bJN62"
+    "NkgXz/U0Tyf4V7BEd82bxn/eChP34sTWb5AA2+iyp4MNkqk1j12gBKaxn7vtiXJn"
+    "XIIVXgOS2zezizp8zXrd39Hjd/qWdkZDv4hN/ZMnDuQ9HclYwtamL5Taf9YFKDBw"
+    "puLEOWIalVSCsq28yqvbPg31430JYH0dNWrpC93+Q9UU2UM30Ai6kp5pLo7b18DI"
+    "WnZ+wlB6zQ=="
+)
+_CB_TEST_TLS_SERVER_END_POINT = bytes.fromhex(
+    "ca99f0a27c89a259826d94640a18ffabe26154fe5d23ffa3d2dfdbc07fa87f5b"
+)
 
 
 class TestCryptoDatum(unittest.TestCase):
@@ -490,6 +518,88 @@ class TestCryptoFunctions(unittest.TestCase):
 
         self.assertTrue(py_scram.scram_constant_time_compare(a, b))
         self.assertFalse(py_scram.scram_constant_time_compare(a, c))
+
+
+class TestChannelBinding(unittest.TestCase):
+    """Test py_scram RFC 5929 tls-server-end-point channel binding."""
+
+    def test_compute_matches_expected(self):
+        binding = py_scram.compute_tls_server_end_point(_CB_TEST_CERT_DER)
+        self.assertIsInstance(binding, py_scram.CryptoDatum)
+        self.assertEqual(bytes(binding), _CB_TEST_TLS_SERVER_END_POINT)
+
+    def test_cb_name_constant(self):
+        self.assertEqual(py_scram.CB_TLS_SERVER_END_POINT, "tls-server-end-point")
+
+    def test_rejects_non_certificate(self):
+        with self.assertRaises(ValueError):
+            py_scram.compute_tls_server_end_point(b"not a certificate")
+
+
+class TestChannelBindingServerSignatureRoundTrip(unittest.TestCase):
+    """Regression test for the cbind-input reconstruction in verify_server_signature.
+
+    A channel-bound exchange built and verified entirely by py_scram must round-trip.
+    verify_server_signature reconstructs the c= attribute to recompute the AuthMessage;
+    if that reconstruction drifts from ClientFinalMessage (e.g. dropping the ',,' that
+    follows the gs2 cbind flag), the bound case fails even though everything is correct.
+    """
+
+    @staticmethod
+    def _auth_data():
+        salt = py_scram.CryptoDatum(b'\x11' * 16)
+        iters = py_scram.SCRAM_MIN_ITERS
+        salted = py_scram.CryptoDatum(
+            hashlib.pbkdf2_hmac('sha512', b'secret', bytes(salt), iters)
+        )
+        return salt, iters, py_scram.generate_scram_auth_data(
+            salted_password=salted, salt=salt, iterations=iters
+        )
+
+    @staticmethod
+    def _server_final(cf, sf, fin, server_key):
+        """Build the SERVER_FINAL_MESSAGE the way a server would: sign the AuthMessage
+        (which embeds the client's c= verbatim) with HMAC(ServerKey, ...)."""
+        c_attr = next(p[2:] for p in str(fin).split(',') if p.startswith('c='))
+        r_attr = next(p[2:] for p in str(fin).split(',') if p.startswith('r='))
+        bare = str(cf).split(',,', 1)[1]
+        auth_msg = f'{bare},{sf},c={c_attr},r={r_attr}'
+        sig = hmac.new(bytes(server_key), auth_msg.encode(), 'sha512').digest()
+        return py_scram.ServerFinalMessage(rfc_string=f'v={b64encode(sig).decode()}')
+
+    def test_bound_round_trip(self):
+        salt, iters, auth = self._auth_data()
+        binding = py_scram.compute_tls_server_end_point(_CB_TEST_CERT_DER)
+        cf = py_scram.ClientFirstMessage(
+            username='u', api_key_id=5,
+            channel_binding_type=py_scram.CB_TLS_SERVER_END_POINT,
+        )
+        sf = py_scram.ServerFirstMessage(client_first=cf, salt=salt, iterations=iters)
+        fin = py_scram.ClientFinalMessage(
+            client_first=cf, server_first=sf,
+            client_key=auth.client_key, stored_key=auth.stored_key,
+            channel_binding=binding,
+        )
+        server_final = self._server_final(cf, sf, fin, auth.server_key)
+        # Must not raise: the reconstructed c= must match what the client sent.
+        py_scram.verify_server_signature(
+            client_first=cf, server_first=sf, client_final=fin,
+            server_final=server_final, server_key=auth.server_key,
+        )
+
+    def test_unbound_round_trip(self):
+        salt, iters, auth = self._auth_data()
+        cf = py_scram.ClientFirstMessage(username='u', api_key_id=5)
+        sf = py_scram.ServerFirstMessage(client_first=cf, salt=salt, iterations=iters)
+        fin = py_scram.ClientFinalMessage(
+            client_first=cf, server_first=sf,
+            client_key=auth.client_key, stored_key=auth.stored_key,
+        )
+        server_final = self._server_final(cf, sf, fin, auth.server_key)
+        py_scram.verify_server_signature(
+            client_first=cf, server_first=sf, client_final=fin,
+            server_final=server_final, server_key=auth.server_key,
+        )
 
 
 if __name__ == '__main__':

--- a/tests/scram/test_scram_client.py
+++ b/tests/scram/test_scram_client.py
@@ -448,5 +448,23 @@ class TestTNScramClientFullFlow(unittest.TestCase):
         self.assertTrue(result)
 
 
+class TestTNScramClientChannelBinding(unittest.TestCase):
+    """Test SCRAM-PLUS channel binding plumbing in TNScramClient."""
+
+    def test_client_first_uses_p_gs2_flag(self):
+        """channel_binding_type produces a "p=<cb-name>" gs2 cbind flag on the wire."""
+        client = TNScramClient(raw_key_material="test_password", api_key_id=7)
+        msg = client.get_client_first_message(
+            username="testuser", channel_binding_type="tls-server-end-point"
+        )
+        self.assertTrue(msg["rfc_str"].startswith("p=tls-server-end-point,,"))
+
+    def test_client_first_without_binding_is_unbound(self):
+        """Without channel binding the gs2 header is the no-binding "n,," flag."""
+        client = TNScramClient(raw_key_material="test_password", api_key_id=7)
+        msg = client.get_client_first_message(username="testuser")
+        self.assertTrue(msg["rfc_str"].startswith("n,,"))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_auth_api_key.py
+++ b/tests/test_auth_api_key.py
@@ -466,7 +466,7 @@ class TestResolveChannelBinding(unittest.TestCase):
 
 
 class TestMidcltChannelBindingFlag(unittest.TestCase):
-    """Test the midclt --no-channel-binding CLI flag."""
+    """Test the midclt --no-channel-binding and --plain CLI flags."""
 
     def test_default_keeps_channel_binding_enabled(self):
         args = get_parser().parse_args(['call', 'system.info'])
@@ -475,6 +475,14 @@ class TestMidcltChannelBindingFlag(unittest.TestCase):
     def test_flag_disables_channel_binding(self):
         args = get_parser().parse_args(['--no-channel-binding', 'call', 'system.info'])
         self.assertTrue(args.no_channel_binding)
+
+    def test_default_uses_scram_not_plain(self):
+        args = get_parser().parse_args(['call', 'system.info'])
+        self.assertFalse(args.plain)
+
+    def test_plain_flag_selects_plain(self):
+        args = get_parser().parse_args(['--plain', 'call', 'system.info'])
+        self.assertTrue(args.plain)
 
 
 class _CallStubClient:
@@ -494,43 +502,53 @@ class _CallStubClient:
 
 
 # A syntactically valid raw API key (<id>-<key>). The SCRAM path (which would run
-# PBKDF2 on this) is never reached by these AUTO-policy tests.
+# PBKDF2 on this) is never reached by these mechanism-policy tests.
 _RAW_KEY = '7-' + 'a' * 64
 
 
-class TestApiKeyAutoChannelBindingPolicy(unittest.TestCase):
-    """AUTO must fail closed instead of silently downgrading to plaintext API-key auth
-    when channel binding was requested but the server does not advertise SCRAM."""
+class TestApiKeyMechanismPolicy(unittest.TestCase):
+    """The client must never auto-downgrade to plaintext. SCRAM (the default) refuses --
+    without transmitting the key -- when the server does not advertise SCRAM; PLAIN is an
+    explicit opt-in that sends the key."""
 
-    def test_auto_cb_required_no_scram_raises(self):
+    def test_scram_no_scram_server_raises_without_sending_key(self):
         c = _CallStubClient(['API_KEY_PLAIN'])
         with self.assertRaises(ValueError) as ctx:
             auth_api_key.api_key_authenticate(
-                c, auth_api_key.APIKeyAuthMech.AUTO, 'user', _RAW_KEY,
-                channel_binding=True,
+                c, auth_api_key.APIKeyAuthMech.SCRAM, 'user', _RAW_KEY,
             )
-        self.assertIn('channel_binding=False', str(ctx.exception))
-        # Critically, the key must NOT have been transmitted before the refusal.
+        # Points the caller at the explicit opt-in...
+        self.assertIn('PLAIN', str(ctx.exception))
+        # ...and, security-critical, the key was NOT transmitted before the refusal.
         self.assertNotIn('auth.login_ex', c.calls)
 
-    def test_auto_cb_disabled_no_scram_falls_back_to_plain(self):
+    def test_explicit_plain_sends_key(self):
         c = _CallStubClient(['API_KEY_PLAIN'])
         auth_api_key.api_key_authenticate(
-            c, auth_api_key.APIKeyAuthMech.AUTO, 'user', _RAW_KEY,
-            channel_binding=False,
+            c, auth_api_key.APIKeyAuthMech.PLAIN, 'user', _RAW_KEY,
         )
-        # The opt-out lets AUTO complete the unbound PLAIN exchange.
+        # The explicit opt-in completes the plaintext exchange.
         self.assertIn('auth.login_ex', c.calls)
 
-    def test_legacy_endpoint_not_blocked_by_default_channel_binding(self):
-        # LegacyClient leaves channel_binding at its default True but talks to servers
-        # that never had SCRAM; the fail-closed guard must not make it unusable.
+    def test_legacy_endpoint_uses_plain_path(self):
+        # LegacyClient authenticates via PLAIN over the legacy /websocket endpoint.
         c = _CallStubClient(['API_KEY_PLAIN'])
         auth_api_key.api_key_authenticate(
-            c, auth_api_key.APIKeyAuthMech.AUTO, 'user', _RAW_KEY,
-            use_legacy_endpoint=True, channel_binding=True,
+            c, auth_api_key.APIKeyAuthMech.PLAIN, 'user', _RAW_KEY,
+            use_legacy_endpoint=True,
         )
         self.assertIn('auth.login_with_api_key', c.calls)
+
+    def test_jsonrpc_login_defaults_to_scram(self):
+        # Lock the security-relevant default: API-key login must default to SCRAM, never a
+        # mechanism that could transmit the key in plaintext.
+        import inspect
+        from truenas_api_client import JSONRPCClient
+        sig = inspect.signature(JSONRPCClient.login_with_api_key)
+        self.assertEqual(
+            sig.parameters['auth_mechanism'].default,
+            auth_api_key.APIKeyAuthMech.SCRAM,
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_auth_api_key.py
+++ b/tests/test_auth_api_key.py
@@ -477,5 +477,61 @@ class TestMidcltChannelBindingFlag(unittest.TestCase):
         self.assertTrue(args.no_channel_binding)
 
 
+class _CallStubClient:
+    """Minimal Client stand-in: canned auth.mechanism_choices, records every call."""
+
+    def __init__(self, mechanisms, *, responses=None):
+        self._mechanisms = mechanisms
+        self._responses = responses or {}
+        self.calls = []
+
+    def call(self, method, *args):
+        self.calls.append(method)
+        if method == 'auth.mechanism_choices':
+            return self._mechanisms
+        # Default to a generic SUCCESS so the PLAIN/legacy paths complete.
+        return self._responses.get(method, {'response_type': 'SUCCESS'})
+
+
+# A syntactically valid raw API key (<id>-<key>). The SCRAM path (which would run
+# PBKDF2 on this) is never reached by these AUTO-policy tests.
+_RAW_KEY = '7-' + 'a' * 64
+
+
+class TestApiKeyAutoChannelBindingPolicy(unittest.TestCase):
+    """AUTO must fail closed instead of silently downgrading to plaintext API-key auth
+    when channel binding was requested but the server does not advertise SCRAM."""
+
+    def test_auto_cb_required_no_scram_raises(self):
+        c = _CallStubClient(['API_KEY_PLAIN'])
+        with self.assertRaises(ValueError) as ctx:
+            auth_api_key.api_key_authenticate(
+                c, auth_api_key.APIKeyAuthMech.AUTO, 'user', _RAW_KEY,
+                channel_binding=True,
+            )
+        self.assertIn('channel_binding=False', str(ctx.exception))
+        # Critically, the key must NOT have been transmitted before the refusal.
+        self.assertNotIn('auth.login_ex', c.calls)
+
+    def test_auto_cb_disabled_no_scram_falls_back_to_plain(self):
+        c = _CallStubClient(['API_KEY_PLAIN'])
+        auth_api_key.api_key_authenticate(
+            c, auth_api_key.APIKeyAuthMech.AUTO, 'user', _RAW_KEY,
+            channel_binding=False,
+        )
+        # The opt-out lets AUTO complete the unbound PLAIN exchange.
+        self.assertIn('auth.login_ex', c.calls)
+
+    def test_legacy_endpoint_not_blocked_by_default_channel_binding(self):
+        # LegacyClient leaves channel_binding at its default True but talks to servers
+        # that never had SCRAM; the fail-closed guard must not make it unusable.
+        c = _CallStubClient(['API_KEY_PLAIN'])
+        auth_api_key.api_key_authenticate(
+            c, auth_api_key.APIKeyAuthMech.AUTO, 'user', _RAW_KEY,
+            use_legacy_endpoint=True, channel_binding=True,
+        )
+        self.assertIn('auth.login_with_api_key', c.calls)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_auth_api_key.py
+++ b/tests/test_auth_api_key.py
@@ -6,15 +6,21 @@ without requiring a live TrueNAS server connection.
 """
 
 import json
+import socket
+import ssl
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
+import truenas_api_client.auth_api_key as auth_api_key
+from truenas_api_client import WSClient, get_parser
 from truenas_api_client.auth_api_key import (
     KeyData,
     KeyDataType,
     RAW_KEY_SEPARATOR,
     _parse_ini_config,
+    _resolve_channel_binding,
     get_key_material,
 )
 
@@ -364,6 +370,111 @@ class TestKeyDataType(unittest.TestCase):
         """Test KeyDataType can be compared."""
         self.assertEqual(KeyDataType.RAW, KeyDataType.RAW)
         self.assertNotEqual(KeyDataType.RAW, KeyDataType.PRECOMPUTED)
+
+
+class TestPeerCertAccessor(unittest.TestCase):
+    """Test WSClient.get_peer_cert_der (source of the SCRAM channel binding)."""
+
+    @staticmethod
+    def _ws():
+        return WSClient("ws+unix:///run/middleware.sock", client=None)
+
+    def test_no_socket_returns_none(self):
+        # Before connect() no socket has been assigned.
+        self.assertIsNone(self._ws().get_peer_cert_der())
+
+    def test_non_tls_socket_returns_none(self):
+        ws = self._ws()
+        ws.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            self.assertIsNone(ws.get_peer_cert_der())
+        finally:
+            ws.socket.close()
+
+    def test_tls_socket_returns_der(self):
+        ws = self._ws()
+        ws.socket = mock.Mock(spec=ssl.SSLSocket)
+        ws.socket.getpeercert.return_value = b"DER-CERT-BYTES"
+        self.assertEqual(ws.get_peer_cert_der(), b"DER-CERT-BYTES")
+        ws.socket.getpeercert.assert_called_once_with(binary_form=True)
+
+
+class _StubWS:
+    """Minimal WSClient stand-in for channel-binding policy tests."""
+
+    def __init__(self, *, cert_der=None, url=''):
+        self._cert_der = cert_der
+        self.url = url
+
+    def get_peer_cert_der(self):
+        return self._cert_der
+
+
+class _StubClient:
+    def __init__(self, ws):
+        self._ws = ws
+
+
+class TestResolveChannelBinding(unittest.TestCase):
+    """Test the SCRAM channel-binding policy (_resolve_channel_binding).
+
+    Policy: channel_binding=True requires a binding (TLS binds; the local UNIX socket is
+    exempt; any other non-TLS transport or a backend without support raises).
+    channel_binding=False is always unbound.
+    """
+
+    def test_disabled_is_unbound_over_tls(self):
+        c = _StubClient(_StubWS(cert_der=b'DER', url='wss://nas/api/current'))
+        self.assertIsNone(_resolve_channel_binding(c, False))
+
+    def test_disabled_is_unbound_over_non_tls(self):
+        c = _StubClient(_StubWS(url='ws://nas/api/current'))
+        self.assertIsNone(_resolve_channel_binding(c, False))
+
+    def test_tls_returns_binding(self):
+        c = _StubClient(_StubWS(cert_der=b'DER', url='wss://nas/api/current'))
+        with mock.patch.object(auth_api_key, 'compute_tls_server_end_point',
+                               return_value='BINDING') as m:
+            self.assertEqual(_resolve_channel_binding(c, True), 'BINDING')
+        m.assert_called_once_with(b'DER')
+
+    def test_tls_but_backend_without_support_raises(self):
+        c = _StubClient(_StubWS(cert_der=b'DER', url='wss://nas/api/current'))
+        with mock.patch.object(auth_api_key, 'compute_tls_server_end_point', None):
+            with self.assertRaises(ValueError) as ctx:
+                _resolve_channel_binding(c, True)
+        self.assertIn('channel_binding=False', str(ctx.exception))
+
+    def test_unix_socket_is_exempt(self):
+        # Local IPC: a required binding resolves to unbound rather than failing.
+        c = _StubClient(_StubWS(url='ws+unix:///run/middleware.sock'))
+        self.assertIsNone(_resolve_channel_binding(c, True))
+
+    def test_non_tls_network_raises(self):
+        c = _StubClient(_StubWS(url='ws://nas/api/current'))
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_channel_binding(c, True)
+        self.assertIn('TLS', str(ctx.exception))
+        self.assertIn('channel_binding=False', str(ctx.exception))
+
+    def test_missing_transport_raises_when_required(self):
+        with self.assertRaises(ValueError):
+            _resolve_channel_binding(_StubClient(None), True)
+
+    def test_missing_transport_disabled_is_unbound(self):
+        self.assertIsNone(_resolve_channel_binding(_StubClient(None), False))
+
+
+class TestMidcltChannelBindingFlag(unittest.TestCase):
+    """Test the midclt --no-channel-binding CLI flag."""
+
+    def test_default_keeps_channel_binding_enabled(self):
+        args = get_parser().parse_args(['call', 'system.info'])
+        self.assertFalse(args.no_channel_binding)
+
+    def test_flag_disables_channel_binding(self):
+        args = get_parser().parse_args(['--no-channel-binding', 'call', 'system.info'])
+        self.assertTrue(args.no_channel_binding)
 
 
 if __name__ == '__main__':

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -181,6 +181,19 @@ class WSClient:
         )
         Thread(daemon=True, target=self.app.run_forever).start()
 
+    def get_peer_cert_der(self) -> bytes | None:
+        """Return the server's TLS certificate in DER form, or `None` for a non-TLS
+        transport (unix socket, plain `ws://`, or reserved-port connection).
+
+        Used to compute the RFC 5929 tls-server-end-point SCRAM channel binding. The
+        certificate is retrievable even when `verify_ssl` is `False`.
+        """
+        sock = getattr(self, 'socket', None)
+        if isinstance(sock, ssl.SSLSocket):
+            return sock.getpeercert(binary_form=True)
+
+        return None
+
     def send(self, data: bytes | str):
         """Send data to the server by calling `WebSocketApp.send()`.
 
@@ -976,7 +989,9 @@ class JSONRPCClient:
         self,
         username: str,
         api_key: str,
-        auth_mechanism: APIKeyAuthMech = APIKeyAuthMech.AUTO
+        auth_mechanism: APIKeyAuthMech = APIKeyAuthMech.AUTO,
+        *,
+        channel_binding: bool = True,
     ) -> None:
         """
         Helper function to authenticate via API key to the truenas server.
@@ -987,14 +1002,22 @@ class JSONRPCClient:
             api_key: either the key material or an absolute path to the file where it is stored
             auth_mechanism: one of "AUTO", "SCRAM", "PLAIN" specifying the type of authentication
                 to perform. AUTO will use SCRAM if support for it is detected.
+            channel_binding: when True (default), SCRAM authentication binds the exchange to
+                the server's TLS certificate (SCRAM-PLUS, RFC 5929 tls-server-end-point) and
+                fails if binding cannot be negotiated -- i.e. on a non-TLS network transport,
+                or against a SCRAM backend too old to compute the binding. The local UNIX
+                socket is exempt. Pass False to authenticate without channel binding, which is
+                required over a plain ``ws://`` connection or against a server that does not
+                support it. Has no effect on PLAIN authentication.
 
         Returns:
             None
 
         Raises:
-            ValueError: an error occurred during authentication.
+            ValueError: an error occurred during authentication, or channel binding was
+                required but could not be established.
         """
-        api_key_authenticate(self, auth_mechanism, username, api_key)
+        api_key_authenticate(self, auth_mechanism, username, api_key, channel_binding=channel_binding)
 
     def login_with_password(self, username: str, password: str, *, otp_token: str | None = None) -> None:
         """
@@ -1115,6 +1138,15 @@ def get_parser():
     parser.add_argument(
         '--insecure', action='store_true',
         help='Disable SSL certificate verification (WARNING: not for production).',
+    )
+    parser.add_argument(
+        '--no-channel-binding', action='store_true',
+        help=(
+            'Disable SCRAM-PLUS channel binding for API-key login. By default, API-key '
+            'authentication over TLS (wss://) binds to the server certificate and fails '
+            'if binding cannot be negotiated. Use this over a plain ws:// connection or '
+            'against a server that does not support channel binding.'
+        ),
     )
 
     subparsers = parser.add_subparsers(
@@ -1243,7 +1275,10 @@ def main():
                     if args.username and args.password:
                         c.login_with_password(args.username, args.password)
                     elif args.api_key:
-                        c.login_with_api_key(args.username, args.api_key)
+                        c.login_with_api_key(
+                            args.username, args.api_key,
+                            channel_binding=not args.no_channel_binding,
+                        )
                 except Exception as e:
                     print("Failed to login: ", e)
                     sys.exit(0)

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -993,7 +993,7 @@ class JSONRPCClient:
         self,
         username: str,
         api_key: str,
-        auth_mechanism: APIKeyAuthMech = APIKeyAuthMech.AUTO,
+        auth_mechanism: APIKeyAuthMech = APIKeyAuthMech.SCRAM,
         *,
         channel_binding: bool = True,
     ) -> None:
@@ -1004,18 +1004,19 @@ class JSONRPCClient:
             username: name of the user that the API key is associated with
                 NOTE: this is required for SCRAM authentication
             api_key: either the key material or an absolute path to the file where it is stored
-            auth_mechanism: one of "AUTO", "SCRAM", "PLAIN" specifying the type of authentication
-                to perform. AUTO will use SCRAM if support for it is detected.
+            auth_mechanism: "SCRAM" (default) or "PLAIN". SCRAM (TrueNAS 26+) never transmits
+                the key over the wire. PLAIN sends the raw API key (protected only by TLS) and
+                must be selected explicitly -- it is required to reach a server that does not
+                support SCRAM (before TrueNAS 26). The client never auto-downgrades to PLAIN:
+                choosing it from the server's unauthenticated advertised mechanisms would let a
+                man-in-the-middle strip SCRAM and harvest the cleartext key.
             channel_binding: when True (default), SCRAM authentication binds the exchange to
                 the server's TLS certificate (SCRAM-PLUS, RFC 5929 tls-server-end-point) and
                 fails if binding cannot be negotiated -- i.e. on a non-TLS network transport,
                 or against a SCRAM backend too old to compute the binding. The local UNIX
-                socket is exempt. With auth_mechanism=AUTO it also fails closed when the server
-                does not support SCRAM, instead of silently downgrading to a plaintext (unbound)
-                API-key exchange that a TLS-terminating man-in-the-middle could harvest. Pass
-                False to authenticate without channel binding -- required over a plain ``ws://``
-                connection, or against a server that does not support SCRAM / channel binding.
-                Ignored for explicit PLAIN authentication.
+                socket is exempt. Pass False to authenticate with SCRAM but without channel
+                binding -- required over a plain ``ws://`` connection, or against a server that
+                supports SCRAM but not channel binding. Ignored for PLAIN authentication.
 
         Returns:
             None
@@ -1155,6 +1156,14 @@ def get_parser():
             'against a server that does not support channel binding.'
         ),
     )
+    parser.add_argument(
+        '--plain', action='store_true',
+        help=(
+            'Authenticate the API key using PLAIN (send the key in plaintext) instead of '
+            'SCRAM. Required for servers that do not support SCRAM (TrueNAS before 26). '
+            'WARNING: transmits the raw API key; only the TLS layer protects it.'
+        ),
+    )
 
     subparsers = parser.add_subparsers(
         dest='name', metavar='<subcommand>',
@@ -1284,6 +1293,10 @@ def main():
                     elif args.api_key:
                         c.login_with_api_key(
                             args.username, args.api_key,
+                            auth_mechanism=(
+                                APIKeyAuthMech.PLAIN if args.plain
+                                else APIKeyAuthMech.SCRAM
+                            ),
                             channel_binding=not args.no_channel_binding,
                         )
                 except Exception as e:

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -187,6 +187,10 @@ class WSClient:
 
         Used to compute the RFC 5929 tls-server-end-point SCRAM channel binding. The
         certificate is retrievable even when `verify_ssl` is `False`.
+
+        Precondition: the TLS handshake must be complete -- true for the SCRAM login
+        flow, which runs after `connect()`. Before the handshake `getpeercert()` returns
+        an empty value, which callers treat as "no certificate" (a falsy result).
         """
         sock = getattr(self, 'socket', None)
         if isinstance(sock, ssl.SSLSocket):
@@ -1006,9 +1010,12 @@ class JSONRPCClient:
                 the server's TLS certificate (SCRAM-PLUS, RFC 5929 tls-server-end-point) and
                 fails if binding cannot be negotiated -- i.e. on a non-TLS network transport,
                 or against a SCRAM backend too old to compute the binding. The local UNIX
-                socket is exempt. Pass False to authenticate without channel binding, which is
-                required over a plain ``ws://`` connection or against a server that does not
-                support it. Has no effect on PLAIN authentication.
+                socket is exempt. With auth_mechanism=AUTO it also fails closed when the server
+                does not support SCRAM, instead of silently downgrading to a plaintext (unbound)
+                API-key exchange that a TLS-terminating man-in-the-middle could harvest. Pass
+                False to authenticate without channel binding -- required over a plain ``ws://``
+                connection, or against a server that does not support SCRAM / channel binding.
+                Ignored for explicit PLAIN authentication.
 
         Returns:
             None

--- a/truenas_api_client/auth_api_key.py
+++ b/truenas_api_client/auth_api_key.py
@@ -230,7 +230,8 @@ def _resolve_channel_binding(c: 'Client', channel_binding: bool) -> CryptoDatum 
         return None
 
     ws = getattr(c, '_ws', None)
-    cert_der = ws.get_peer_cert_der() if ws is not None else None
+    get_cert = getattr(ws, 'get_peer_cert_der', None)
+    cert_der = get_cert() if get_cert is not None else None
     if cert_der:
         if compute_tls_server_end_point is None:
             raise ValueError(
@@ -278,9 +279,13 @@ def api_key_authenticate(
             for the SCRAM mechanism. When True (default) the exchange is bound to the
             server's TLS certificate and authentication fails if binding cannot be
             negotiated (a non-TLS network transport, or a SCRAM backend that cannot
-            compute the binding). The local UNIX socket is exempt. When False the exchange
-            is unbound, which is required to reach servers without channel-binding support.
-            Has no effect on the PLAIN flow, which never uses SCRAM.
+            compute the binding). The local UNIX socket is exempt. With auth_mechanism=AUTO
+            it additionally fails closed if the server does not offer SCRAM at all, rather
+            than silently downgrading to a plaintext (unbound) API-key exchange -- the server
+            enforces no downgrade protection, so the client must. When False the exchange is
+            unbound, which is required to reach servers without SCRAM / channel-binding
+            support. Ignored for an explicit PLAIN mechanism and for the legacy endpoint,
+            neither of which uses SCRAM.
 
     Returns:
         None
@@ -314,7 +319,22 @@ def api_key_authenticate(
         case APIKeyAuthMech.PLAIN:
             do_legacy_auth = True
         case APIKeyAuthMech.AUTO:
-            if MECHANISM_SCRAM not in available_mechanisms or not username:
+            scram_available = MECHANISM_SCRAM in available_mechanisms
+            # Fail closed on a silent channel-binding downgrade: if channel binding was
+            # requested but the server does not offer SCRAM, AUTO would otherwise fall back
+            # to plaintext API-key auth, which cannot be channel-bound. The server enforces
+            # no SCRAM downgrade protection (a MITM that strips SCRAM from
+            # auth.mechanism_choices forces exactly this path), so the client is the only
+            # enforcer -- refuse rather than transmit the key unbound. The legacy endpoint is
+            # exempt: those servers never had SCRAM, so there is no binding to negotiate.
+            if not scram_available and channel_binding and not use_legacy_endpoint:
+                raise ValueError(
+                    'channel binding was requested (channel_binding=True) but the server '
+                    'does not support SCRAM, so the API key would be sent using plaintext '
+                    'authentication, which cannot be channel-bound. Pass channel_binding=False '
+                    'to allow the unbound plaintext flow (the key is still protected by TLS).'
+                )
+            if not scram_available or not username:
                 do_legacy_auth = True
         case APIKeyAuthMech.SCRAM:
             if MECHANISM_SCRAM not in available_mechanisms:

--- a/truenas_api_client/auth_api_key.py
+++ b/truenas_api_client/auth_api_key.py
@@ -32,9 +32,8 @@ UNIX_SOCKET_PREFIX = 'ws+unix://'
 
 
 class APIKeyAuthMech(StrEnum):
-    AUTO = 'AUTO'  # autodetect and try SCRAM if available
-    SCRAM = 'SCRAM'  # only attempt SCRAM auth
-    PLAIN = 'PLAIN'  # only attempt PLAIN auth
+    SCRAM = 'SCRAM'  # SCRAM-SHA-512 (default); never transmits the API key in plaintext
+    PLAIN = 'PLAIN'  # explicit opt-in; transmits the raw API key (only TLS protects it)
 
 
 class KeyDataType(StrEnum):
@@ -266,7 +265,8 @@ def api_key_authenticate(
 
     Arguments:
         c: truenas_api_client.Client() instance
-        auth_mechanism: one of 'AUTO', 'SCRAM', or 'PLAIN'
+        auth_mechanism: 'SCRAM' (default; never sends the key in plaintext) or 'PLAIN'
+            (explicit opt-in that transmits the raw API key)
         username: name of the user that the API key is associated with (required for SCRAM
             and for PLAIN when `use_legacy_endpoint` is False)
         key_in: either the actual key material or an absolute path to a file
@@ -279,13 +279,10 @@ def api_key_authenticate(
             for the SCRAM mechanism. When True (default) the exchange is bound to the
             server's TLS certificate and authentication fails if binding cannot be
             negotiated (a non-TLS network transport, or a SCRAM backend that cannot
-            compute the binding). The local UNIX socket is exempt. With auth_mechanism=AUTO
-            it additionally fails closed if the server does not offer SCRAM at all, rather
-            than silently downgrading to a plaintext (unbound) API-key exchange -- the server
-            enforces no downgrade protection, so the client must. When False the exchange is
-            unbound, which is required to reach servers without SCRAM / channel-binding
-            support. Ignored for an explicit PLAIN mechanism and for the legacy endpoint,
-            neither of which uses SCRAM.
+            compute the binding). The local UNIX socket is exempt. When False the exchange is
+            unbound (still SCRAM), which is required over a plain ``ws://`` connection or
+            against a server that supports SCRAM but not channel binding. Ignored for the
+            PLAIN mechanism and the legacy endpoint, neither of which uses SCRAM.
 
     Returns:
         None
@@ -318,27 +315,17 @@ def api_key_authenticate(
     match auth_mechanism:
         case APIKeyAuthMech.PLAIN:
             do_legacy_auth = True
-        case APIKeyAuthMech.AUTO:
-            scram_available = MECHANISM_SCRAM in available_mechanisms
-            # Fail closed on a silent channel-binding downgrade: if channel binding was
-            # requested but the server does not offer SCRAM, AUTO would otherwise fall back
-            # to plaintext API-key auth, which cannot be channel-bound. The server enforces
-            # no SCRAM downgrade protection (a MITM that strips SCRAM from
-            # auth.mechanism_choices forces exactly this path), so the client is the only
-            # enforcer -- refuse rather than transmit the key unbound. The legacy endpoint is
-            # exempt: those servers never had SCRAM, so there is no binding to negotiate.
-            if not scram_available and channel_binding and not use_legacy_endpoint:
-                raise ValueError(
-                    'channel binding was requested (channel_binding=True) but the server '
-                    'does not support SCRAM, so the API key would be sent using plaintext '
-                    'authentication, which cannot be channel-bound. Pass channel_binding=False '
-                    'to allow the unbound plaintext flow (the key is still protected by TLS).'
-                )
-            if not scram_available or not username:
-                do_legacy_auth = True
         case APIKeyAuthMech.SCRAM:
+            # SCRAM is the default and never transmits the key in plaintext. We deliberately
+            # do NOT auto-fall-back to PLAIN when the server omits SCRAM: auth.mechanism_choices
+            # is unauthenticated, so a MITM that strips SCRAM from it could otherwise force a
+            # silent downgrade and harvest the cleartext key. Reaching a server without SCRAM is
+            # therefore an explicit, informed choice (auth_mechanism=PLAIN).
             if MECHANISM_SCRAM not in available_mechanisms:
-                raise ValueError('SCRAM authentication is not supported on the remote server')
+                raise ValueError(
+                    'SCRAM authentication is not supported on the remote server; pass '
+                    'auth_mechanism="PLAIN" to authenticate with a plaintext API key'
+                )
 
             if not username:
                 raise ValueError('username is required for SCRAM authentication')

--- a/truenas_api_client/auth_api_key.py
+++ b/truenas_api_client/auth_api_key.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, TypedDict
 
 from .ejson import loads
 from .exc import ClientException
-from .scram_impl import CryptoDatum, TNScramClient
+from .scram_impl import CB_TLS_SERVER_END_POINT, CryptoDatum, TNScramClient, compute_tls_server_end_point
 
 if TYPE_CHECKING:
     from . import Client
@@ -24,6 +24,11 @@ MECHANISM_SCRAM = 'SCRAM'
 MECHANISM_API_KEY_PLAIN = 'API_KEY_PLAIN'
 RESPONSE_TYPE_SCRAM = 'SCRAM_RESPONSE'
 RESPONSE_TYPE_AUTH_ERR = 'AUTH_ERR'
+
+# Websocket URI prefix for the local middleware UNIX domain socket. Channel binding is
+# meaningless for local IPC (no TLS, no MITM surface), so this transport is exempt from
+# the channel_binding=True requirement.
+UNIX_SOCKET_PREFIX = 'ws+unix://'
 
 
 class APIKeyAuthMech(StrEnum):
@@ -200,6 +205,51 @@ def _raise_for_api_key_response(resp: dict) -> None:
             raise ValueError(f'{other}: unexpected server response')
 
 
+def _resolve_channel_binding(c: 'Client', channel_binding: bool) -> CryptoDatum | None:
+    """Resolve the SCRAM channel binding to use for the current connection.
+
+    Returns the RFC 5929 ``tls-server-end-point`` binding for a TLS (``wss://``)
+    connection, or ``None`` for an unbound exchange.
+
+    When ``channel_binding`` is ``True`` (the default), the API-key SCRAM exchange must
+    be channel-bound: the server certificate is read from the live TLS socket (which
+    works even with ``verify_ssl=False``) and folded into the SCRAM proof. The local
+    UNIX socket is exempt, since channel binding is meaningless for local IPC. Any other
+    non-TLS transport, or a ``truenas_pyscram`` backend too old to compute the binding,
+    cannot satisfy the requirement and raises.
+
+    When ``channel_binding`` is ``False`` the exchange is always unbound (``n,,``), which
+    stays compatible with negotiate-mode servers and servers that predate channel binding.
+
+    Raises:
+        ValueError: channel binding was required but could not be established because the
+            connection is not TLS, or the active ``truenas_pyscram`` backend cannot
+            compute the binding.
+    """
+    if not channel_binding:
+        return None
+
+    ws = getattr(c, '_ws', None)
+    cert_der = ws.get_peer_cert_der() if ws is not None else None
+    if cert_der:
+        if compute_tls_server_end_point is None:
+            raise ValueError(
+                'channel binding is required but the installed truenas_pyscram does not '
+                'support it; upgrade truenas_pyscram or pass channel_binding=False'
+            )
+        return compute_tls_server_end_point(cert_der)
+
+    # No TLS certificate is available on this transport. The local UNIX socket is exempt;
+    # any other non-TLS transport cannot carry channel binding.
+    if (getattr(ws, 'url', '') or '').startswith(UNIX_SOCKET_PREFIX):
+        return None
+
+    raise ValueError(
+        'channel binding is required but the connection is not TLS (wss://); '
+        'pass channel_binding=False to authenticate without it'
+    )
+
+
 def api_key_authenticate(
     c: 'Client',
     auth_mechanism: APIKeyAuthMech,
@@ -207,6 +257,7 @@ def api_key_authenticate(
     key_in: str | None,
     *,
     use_legacy_endpoint: bool = False,
+    channel_binding: bool = True,
 ) -> None:
     """
     Perform API key authentication on an already-existing middleware
@@ -223,13 +274,21 @@ def api_key_authenticate(
             uses `auth.login_ex` with `API_KEY_PLAIN`. When True (for LegacyClient talking
             to old TrueNAS over `/websocket`) the PLAIN flow uses `auth.login_with_api_key`
             because the server predates `auth.login_ex`.
+        channel_binding: governs SCRAM-PLUS channel binding (RFC 5929 tls-server-end-point)
+            for the SCRAM mechanism. When True (default) the exchange is bound to the
+            server's TLS certificate and authentication fails if binding cannot be
+            negotiated (a non-TLS network transport, or a SCRAM backend that cannot
+            compute the binding). The local UNIX socket is exempt. When False the exchange
+            is unbound, which is required to reach servers without channel-binding support.
+            Has no effect on the PLAIN flow, which never uses SCRAM.
 
     Returns:
         None
 
     Raises:
         ValueError:
-            API key is not valid for server / user
+            API key is not valid for server / user, or channel binding was required but
+            could not be established (see `channel_binding`).
     """
     if key_in is None:
         raise ValueError('API key is required')
@@ -309,7 +368,15 @@ def api_key_authenticate(
             api_key_id=precomputed_data['api_key_id']
         )
 
-    client_first_message = sc.get_client_first_message(username)
+    # SCRAM-PLUS channel binding (RFC 5929 tls-server-end-point): by default the exchange
+    # is bound to the server's TLS certificate and authentication fails if a binding
+    # cannot be negotiated. _resolve_channel_binding implements the policy (TLS binds,
+    # local UNIX socket is exempt, other non-TLS transports raise) and the
+    # channel_binding=False escape hatch for servers without channel-binding support.
+    binding = _resolve_channel_binding(c, channel_binding)
+    first_kwargs = {'channel_binding_type': CB_TLS_SERVER_END_POINT} if binding else {}
+
+    client_first_message = sc.get_client_first_message(username, **first_kwargs)
 
     # Send our first client SCRAM message that provides client nonce to server and provides what key identifier
     # is being used server-side.
@@ -322,7 +389,9 @@ def api_key_authenticate(
     elif resp_type != RESPONSE_TYPE_SCRAM:
         raise ValueError(f'{resp_type}: unexpected server response')
 
-    client_final_message = sc.get_client_final_message(server_resp_dict=resp)
+    client_final_message = sc.get_client_final_message(
+        server_resp_dict=resp, channel_binding=binding
+    )
 
     # Send our client SCRAM final message that provides client proof to server
     resp = c.call('auth.login_ex', {'mechanism': MECHANISM_SCRAM} | client_final_message)

--- a/truenas_api_client/legacy.py
+++ b/truenas_api_client/legacy.py
@@ -117,6 +117,10 @@ class WSClient:
         """Return the server's TLS certificate in DER form, or `None` for a non-TLS
         transport. Used to compute the RFC 5929 tls-server-end-point SCRAM channel
         binding (retrievable even when `verify_ssl` is `False`).
+
+        Precondition: the TLS handshake must be complete (true once `connect()` has run,
+        before any login); before that `getpeercert()` yields an empty value that callers
+        treat as "no certificate".
         """
         if isinstance(self.socket, ssl.SSLSocket):
             return self.socket.getpeercert(binary_form=True)

--- a/truenas_api_client/legacy.py
+++ b/truenas_api_client/legacy.py
@@ -113,6 +113,16 @@ class WSClient:
 
         self.client.on_open()
 
+    def get_peer_cert_der(self) -> bytes | None:
+        """Return the server's TLS certificate in DER form, or `None` for a non-TLS
+        transport. Used to compute the RFC 5929 tls-server-end-point SCRAM channel
+        binding (retrievable even when `verify_ssl` is `False`).
+        """
+        if isinstance(self.socket, ssl.SSLSocket):
+            return self.socket.getpeercert(binary_form=True)
+
+        return None
+
     def _on_message(self, app, data):
         self.client._recv(json.loads(data))
 
@@ -489,7 +499,9 @@ class LegacyClient:
         self,
         username: str,
         api_key: str,
-        auth_mechanism: APIKeyAuthMech = APIKeyAuthMech.PLAIN
+        auth_mechanism: APIKeyAuthMech = APIKeyAuthMech.PLAIN,
+        *,
+        channel_binding: bool = True,
     ) -> None:
         """
         Helper function to authenticate via API key to the truenas server. Legacy TrueNAS servers
@@ -503,6 +515,9 @@ class LegacyClient:
             api_key: either the key material or an absolute path to the file where it is stored
             auth_mechanism: one of "AUTO", "PLAIN" specifying the type of authentication. A ValueError
                will be raised if SCRAM is specified.
+            channel_binding: ignored for legacy clients. Legacy TrueNAS servers do not implement
+               SCRAM, so there is no channel binding to negotiate. It exists to ensure consistent
+               function signatures for API consumers.
 
         Returns:
             None

--- a/truenas_api_client/legacy.py
+++ b/truenas_api_client/legacy.py
@@ -517,8 +517,9 @@ class LegacyClient:
             username: this parameter is ignored for legacy clients. It exists to ensure consistent
                function signatures for API consumers.
             api_key: either the key material or an absolute path to the file where it is stored
-            auth_mechanism: one of "AUTO", "PLAIN" specifying the type of authentication. A ValueError
-               will be raised if SCRAM is specified.
+            auth_mechanism: "PLAIN" is the only supported value -- legacy servers cannot do SCRAM,
+               so a ValueError is raised if SCRAM is specified. Kept for signature parity with the
+               non-legacy client.
             channel_binding: ignored for legacy clients. Legacy TrueNAS servers do not implement
                SCRAM, so there is no channel binding to negotiate. It exists to ensure consistent
                function signatures for API consumers.

--- a/truenas_api_client/py_scram/__init__.py
+++ b/truenas_api_client/py_scram/__init__.py
@@ -40,6 +40,11 @@ from .common import (
     ScramAuthData,
 )
 
+from .channel_binding import (
+    CB_TLS_SERVER_END_POINT,
+    compute_tls_server_end_point,
+)
+
 from .client_first import ClientFirstMessage
 from .server_first import ServerFirstMessage
 from .client_final import ClientFinalMessage
@@ -68,6 +73,10 @@ __all__ = [
     # Verification functions
     'verify_server_signature',
     'verify_client_final_message',
+
+    # Channel binding
+    'CB_TLS_SERVER_END_POINT',
+    'compute_tls_server_end_point',
 
     # Auth data generation
     'generate_scram_auth_data',

--- a/truenas_api_client/py_scram/channel_binding.py
+++ b/truenas_api_client/py_scram/channel_binding.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Pure python RFC 5929 tls-server-end-point channel binding.
+#
+# Mirrors scram_compute_tls_server_end_point() in the truenas_scram C library so
+# that py_scram and the truenas_pyscram cpython extension produce identical
+# bindings for the same certificate.
+
+import hashlib
+
+from .scram_crypto import CryptoDatum
+
+
+__all__ = ['CB_TLS_SERVER_END_POINT', 'compute_tls_server_end_point']
+
+
+# RFC 5929 channel-binding type name (the "cb-name" in a "p=" gs2 flag).
+CB_TLS_SERVER_END_POINT = 'tls-server-end-point'
+
+
+# Map a certificate signatureAlgorithm OID to the digest used for
+# tls-server-end-point. Per RFC 5929 4.1 the certificate's own signature hash is
+# used, except MD5 and SHA-1 are promoted to SHA-256. Values below are the
+# already-promoted (effective) digest names.
+_SIG_OID_TO_HASH = {
+    # RSASSA-PKCS1-v1_5
+    '1.2.840.113549.1.1.4': 'sha256',   # md5WithRSAEncryption  -> promoted
+    '1.2.840.113549.1.1.5': 'sha256',   # sha1WithRSAEncryption -> promoted
+    '1.2.840.113549.1.1.14': 'sha224',  # sha224WithRSAEncryption
+    '1.2.840.113549.1.1.11': 'sha256',  # sha256WithRSAEncryption
+    '1.2.840.113549.1.1.12': 'sha384',  # sha384WithRSAEncryption
+    '1.2.840.113549.1.1.13': 'sha512',  # sha512WithRSAEncryption
+    # ECDSA
+    '1.2.840.10045.4.1': 'sha256',      # ecdsa-with-SHA1 -> promoted
+    '1.2.840.10045.4.3.1': 'sha224',    # ecdsa-with-SHA224
+    '1.2.840.10045.4.3.2': 'sha256',    # ecdsa-with-SHA256
+    '1.2.840.10045.4.3.3': 'sha384',    # ecdsa-with-SHA384
+    '1.2.840.10045.4.3.4': 'sha512',    # ecdsa-with-SHA512
+}
+
+
+def _read_tlv(buf: bytes, offset: int) -> tuple[int, int, int]:
+    """Read a DER TLV header. Returns (tag, value_start, value_end).
+
+    Only the low-tag-number form is handled, which is all that is needed to reach
+    a certificate's signatureAlgorithm (SEQUENCE/OBJECT IDENTIFIER tags).
+    """
+    tag = buf[offset]
+    ptr = offset + 1
+    length_byte = buf[ptr]
+    ptr += 1
+    if length_byte < 0x80:
+        length = length_byte
+    else:
+        num = length_byte & 0x7f
+        length = int.from_bytes(buf[ptr:ptr + num], 'big')
+        ptr += num
+    return tag, ptr, ptr + length
+
+
+def _decode_oid(data: bytes) -> str:
+    first = data[0]
+    parts = [str(first // 40), str(first % 40)]
+    value = 0
+    for byte in data[1:]:
+        value = (value << 7) | (byte & 0x7f)
+        if not byte & 0x80:
+            parts.append(str(value))
+            value = 0
+    return '.'.join(parts)
+
+
+def _signature_algorithm_oid(cert_der: bytes) -> str:
+    # Certificate ::= SEQUENCE { tbsCertificate SEQUENCE, signatureAlgorithm SEQUENCE, ... }
+    tag, cert_start, _ = _read_tlv(cert_der, 0)
+    if tag != 0x30:
+        raise ValueError('not a DER certificate')
+
+    # Skip tbsCertificate.
+    tag, _, after_tbs = _read_tlv(cert_der, cert_start)
+    if tag != 0x30:
+        raise ValueError('malformed certificate (tbsCertificate)')
+
+    # signatureAlgorithm ::= SEQUENCE { algorithm OBJECT IDENTIFIER, parameters ANY }
+    tag, sig_alg_start, _ = _read_tlv(cert_der, after_tbs)
+    if tag != 0x30:
+        raise ValueError('malformed certificate (signatureAlgorithm)')
+
+    tag, oid_start, oid_end = _read_tlv(cert_der, sig_alg_start)
+    if tag != 0x06:
+        raise ValueError('malformed certificate (algorithm OID)')
+
+    return _decode_oid(cert_der[oid_start:oid_end])
+
+
+def compute_tls_server_end_point(cert_der: bytes) -> CryptoDatum:
+    """Compute the RFC 5929 tls-server-end-point channel binding for a DER cert.
+
+    The binding is the certificate hashed with the digest from its own signature
+    algorithm (MD5/SHA-1 promoted to SHA-256). Signature algorithms with no single
+    well-defined hash (e.g. EdDSA, RSASSA-PSS) are rejected, matching the C library.
+    """
+    oid = _signature_algorithm_oid(bytes(cert_der))
+    hash_name = _SIG_OID_TO_HASH.get(oid)
+    if hash_name is None:
+        raise ValueError(f'tls-server-end-point is undefined for signature algorithm {oid}')
+
+    digest = hashlib.new(hash_name, bytes(cert_der)).digest()
+    return CryptoDatum(digest)

--- a/truenas_api_client/py_scram/channel_binding.py
+++ b/truenas_api_client/py_scram/channel_binding.py
@@ -3,7 +3,17 @@
 #
 # Mirrors scram_compute_tls_server_end_point() in the truenas_scram C library so
 # that py_scram and the truenas_pyscram cpython extension produce identical
-# bindings for the same certificate.
+# bindings for the same certificate. The C library selects the digest with
+# OpenSSL's X509_get_signature_info(); the maps and RSASSA-PSS handling below
+# reproduce that selection without an OpenSSL/cryptography dependency.
+#
+# IMPORTANT: this pure-python implementation is a FALLBACK -- it runs only when the
+# truenas_pyscram C extension is not installed (see scram_impl.py, which prefers
+# truenas_pyscram.compute_tls_server_end_point() and drops to py_scram only on
+# ImportError). In a normal install the C extension is present, so the parser below
+# is rarely exercised; that is exactly why it is conformance-tested against both
+# truenas_pyscram (tests/scram/test_compatibility.py) and python-cryptography
+# (tests/scram/test_py_scram.py) across every supported signature algorithm.
 
 import hashlib
 
@@ -17,24 +27,45 @@ __all__ = ['CB_TLS_SERVER_END_POINT', 'compute_tls_server_end_point']
 CB_TLS_SERVER_END_POINT = 'tls-server-end-point'
 
 
-# Map a certificate signatureAlgorithm OID to the digest used for
-# tls-server-end-point. Per RFC 5929 4.1 the certificate's own signature hash is
-# used, except MD5 and SHA-1 are promoted to SHA-256. Values below are the
-# already-promoted (effective) digest names.
+# Map a certificate signatureAlgorithm OID to its *raw* signature digest -- before
+# the RFC 5929 4.1 MD5/SHA-1 -> SHA-256 promotion, which compute_tls_server_end_point
+# applies uniformly below. This mirrors OpenSSL's OBJ_find_sigid_algs() (used by
+# X509_get_signature_info()), which the C library relies on. RSASSA-PSS is handled
+# separately because its digest lives in the signature parameters, not the OID;
+# EdDSA is intentionally absent (no single well-defined hash -> undefined, rejected).
 _SIG_OID_TO_HASH = {
     # RSASSA-PKCS1-v1_5
-    '1.2.840.113549.1.1.4': 'sha256',   # md5WithRSAEncryption  -> promoted
-    '1.2.840.113549.1.1.5': 'sha256',   # sha1WithRSAEncryption -> promoted
+    '1.2.840.113549.1.1.4': 'md5',      # md5WithRSAEncryption  -> promoted to sha256
+    '1.2.840.113549.1.1.5': 'sha1',     # sha1WithRSAEncryption -> promoted to sha256
     '1.2.840.113549.1.1.14': 'sha224',  # sha224WithRSAEncryption
     '1.2.840.113549.1.1.11': 'sha256',  # sha256WithRSAEncryption
     '1.2.840.113549.1.1.12': 'sha384',  # sha384WithRSAEncryption
     '1.2.840.113549.1.1.13': 'sha512',  # sha512WithRSAEncryption
     # ECDSA
-    '1.2.840.10045.4.1': 'sha256',      # ecdsa-with-SHA1 -> promoted
+    '1.2.840.10045.4.1': 'sha1',        # ecdsa-with-SHA1 -> promoted to sha256
     '1.2.840.10045.4.3.1': 'sha224',    # ecdsa-with-SHA224
     '1.2.840.10045.4.3.2': 'sha256',    # ecdsa-with-SHA256
     '1.2.840.10045.4.3.3': 'sha384',    # ecdsa-with-SHA384
     '1.2.840.10045.4.3.4': 'sha512',    # ecdsa-with-SHA512
+    # DSA (OpenSSL resolves these via OBJ_find_sigid_algs; SHA-384/512 DSA have no
+    # OpenSSL sigid and are therefore omitted so we reject them exactly as C does).
+    '1.2.840.10040.4.3': 'sha1',        # id-dsa-with-sha1 -> promoted to sha256
+    '2.16.840.1.101.3.4.3.1': 'sha224',  # id-dsa-with-sha224
+    '2.16.840.1.101.3.4.3.2': 'sha256',  # id-dsa-with-sha256
+}
+
+# RSASSA-PSS encodes its message digest in the signatureAlgorithm parameters
+# (RSASSA-PSS-params), not in the OID, so it is resolved separately.
+_RSASSA_PSS_OID = '1.2.840.113549.1.1.10'
+
+# Digest OIDs that can appear in an RSASSA-PSS hashAlgorithm field.
+_HASH_OID_TO_NAME = {
+    '1.2.840.113549.2.5': 'md5',
+    '1.3.14.3.2.26': 'sha1',
+    '2.16.840.1.101.3.4.2.4': 'sha224',
+    '2.16.840.1.101.3.4.2.1': 'sha256',
+    '2.16.840.1.101.3.4.2.2': 'sha384',
+    '2.16.840.1.101.3.4.2.3': 'sha512',
 }
 
 
@@ -42,8 +73,12 @@ def _read_tlv(buf: bytes, offset: int) -> tuple[int, int, int]:
     """Read a DER TLV header. Returns (tag, value_start, value_end).
 
     Only the low-tag-number form is handled, which is all that is needed to reach
-    a certificate's signatureAlgorithm (SEQUENCE/OBJECT IDENTIFIER tags).
+    a certificate's signatureAlgorithm (SEQUENCE/OBJECT IDENTIFIER tags) and the
+    RSASSA-PSS parameters. Raises ValueError (rather than IndexError) on truncated
+    input, since the certificate comes off the wire.
     """
+    if offset + 2 > len(buf):
+        raise ValueError('truncated DER (TLV header)')
     tag = buf[offset]
     ptr = offset + 1
     length_byte = buf[ptr]
@@ -52,8 +87,12 @@ def _read_tlv(buf: bytes, offset: int) -> tuple[int, int, int]:
         length = length_byte
     else:
         num = length_byte & 0x7f
+        if ptr + num > len(buf):
+            raise ValueError('truncated DER (length)')
         length = int.from_bytes(buf[ptr:ptr + num], 'big')
         ptr += num
+    if ptr + length > len(buf):
+        raise ValueError('truncated DER (value)')
     return tag, ptr, ptr + length
 
 
@@ -69,7 +108,13 @@ def _decode_oid(data: bytes) -> str:
     return '.'.join(parts)
 
 
-def _signature_algorithm_oid(cert_der: bytes) -> str:
+def _signature_algorithm(cert_der: bytes) -> tuple[str, bytes]:
+    """Return (oid, parameters) of the certificate's signatureAlgorithm.
+
+    ``parameters`` is the raw DER of the AlgorithmIdentifier parameters field (the
+    bytes following the algorithm OID), or ``b''`` when absent. Needed for
+    RSASSA-PSS, whose digest is carried there rather than in the OID.
+    """
     # Certificate ::= SEQUENCE { tbsCertificate SEQUENCE, signatureAlgorithm SEQUENCE, ... }
     tag, cert_start, _ = _read_tlv(cert_der, 0)
     if tag != 0x30:
@@ -81,7 +126,7 @@ def _signature_algorithm_oid(cert_der: bytes) -> str:
         raise ValueError('malformed certificate (tbsCertificate)')
 
     # signatureAlgorithm ::= SEQUENCE { algorithm OBJECT IDENTIFIER, parameters ANY }
-    tag, sig_alg_start, _ = _read_tlv(cert_der, after_tbs)
+    tag, sig_alg_start, sig_alg_end = _read_tlv(cert_der, after_tbs)
     if tag != 0x30:
         raise ValueError('malformed certificate (signatureAlgorithm)')
 
@@ -89,20 +134,73 @@ def _signature_algorithm_oid(cert_der: bytes) -> str:
     if tag != 0x06:
         raise ValueError('malformed certificate (algorithm OID)')
 
-    return _decode_oid(cert_der[oid_start:oid_end])
+    oid = _decode_oid(cert_der[oid_start:oid_end])
+    parameters = cert_der[oid_end:sig_alg_end]
+    return oid, parameters
+
+
+def _rsassa_pss_hash(parameters: bytes) -> str:
+    """Extract the message digest from RSASSA-PSS-params.
+
+        RSASSA-PSS-params ::= SEQUENCE {
+            hashAlgorithm [0] AlgorithmIdentifier DEFAULT sha1, ... }
+
+    An absent hashAlgorithm defaults to SHA-1 (RFC 4055), matching what OpenSSL
+    reports for such a certificate (which the RFC 5929 4.1 promotion then maps to
+    SHA-256). Raises ValueError for an unrecognized digest, as the C library does.
+    """
+    if not parameters:
+        return 'sha1'  # all params defaulted
+
+    tag, seq_start, seq_end = _read_tlv(parameters, 0)
+    if tag != 0x30:
+        raise ValueError('malformed RSASSA-PSS parameters')
+    if seq_start >= seq_end:
+        return 'sha1'  # empty SEQUENCE -> all defaults
+
+    # First element, if present, is the [0] EXPLICIT hashAlgorithm.
+    tag, h_start, h_end = _read_tlv(parameters, seq_start)
+    if tag != 0xA0:
+        return 'sha1'  # hashAlgorithm omitted -> default SHA-1
+
+    tag, alg_start, _ = _read_tlv(parameters, h_start)
+    if tag != 0x30:
+        raise ValueError('malformed RSASSA-PSS hashAlgorithm')
+
+    tag, oid_start, oid_end = _read_tlv(parameters, alg_start)
+    if tag != 0x06:
+        raise ValueError('malformed RSASSA-PSS hashAlgorithm OID')
+
+    oid = _decode_oid(parameters[oid_start:oid_end])
+    name = _HASH_OID_TO_NAME.get(oid)
+    if name is None:
+        raise ValueError(f'tls-server-end-point: unsupported RSASSA-PSS hash {oid}')
+    return name
 
 
 def compute_tls_server_end_point(cert_der: bytes) -> CryptoDatum:
     """Compute the RFC 5929 tls-server-end-point channel binding for a DER cert.
 
     The binding is the certificate hashed with the digest from its own signature
-    algorithm (MD5/SHA-1 promoted to SHA-256). Signature algorithms with no single
-    well-defined hash (e.g. EdDSA, RSASSA-PSS) are rejected, matching the C library.
+    algorithm, with MD5 and SHA-1 promoted to SHA-256 (RFC 5929 4.1). RSASSA-PSS is
+    supported by reading the digest from its signature parameters, and DSA/ECDSA/
+    RSA-PKCS1 from the algorithm OID. Signature algorithms with no single
+    well-defined hash (e.g. EdDSA) are rejected. This mirrors OpenSSL's
+    X509_get_signature_info(), which the C library uses.
     """
-    oid = _signature_algorithm_oid(bytes(cert_der))
-    hash_name = _SIG_OID_TO_HASH.get(oid)
+    cert_der = bytes(cert_der)
+    oid, parameters = _signature_algorithm(cert_der)
+
+    if oid == _RSASSA_PSS_OID:
+        hash_name = _rsassa_pss_hash(parameters)
+    else:
+        hash_name = _SIG_OID_TO_HASH.get(oid)
     if hash_name is None:
         raise ValueError(f'tls-server-end-point is undefined for signature algorithm {oid}')
 
-    digest = hashlib.new(hash_name, bytes(cert_der)).digest()
+    # RFC 5929 4.1: MD5 and SHA-1 signature hashes are promoted to SHA-256.
+    if hash_name in ('md5', 'sha1'):
+        hash_name = 'sha256'
+
+    digest = hashlib.new(hash_name, cert_der).digest()
     return CryptoDatum(digest)

--- a/truenas_api_client/py_scram/client_final.py
+++ b/truenas_api_client/py_scram/client_final.py
@@ -115,8 +115,10 @@ class ClientFinalMessage:
 
             # Prepare channel binding for message
             if channel_binding:
-                # Encode GS2 header + channel binding data
-                gs2_header_str = client_first.gs2_header or 'n,,'
+                # cbind-input = gs2-header + cbind-data (RFC 5802 6). The gs2-header is the
+                # cbind flag plus the empty-authzid separator exactly as it appears in
+                # client-first, e.g. "p=tls-server-end-point,,".
+                gs2_header_str = (client_first.gs2_header or 'n') + GS2_SEPARATOR
                 cb_data = gs2_header_str.encode() + bytes(channel_binding)
                 channel_binding_b64 = b64encode(cb_data).decode()
             else:

--- a/truenas_api_client/py_scram/client_first.py
+++ b/truenas_api_client/py_scram/client_first.py
@@ -31,6 +31,7 @@ class ClientFirstMessage:
         username: str,
         api_key_id: int = 0,
         gs2_header: str | None = None,
+        channel_binding_type: str | None = None,
     ):
         if not username:
             raise ValueError('Must specify username')
@@ -43,6 +44,14 @@ class ClientFirstMessage:
 
         if gs2_header and not isinstance(gs2_header, str):
             raise TypeError('GS2 header must be string if provided')
+
+        if channel_binding_type is not None:
+            if not isinstance(channel_binding_type, str):
+                raise TypeError('channel_binding_type must be string if provided')
+            if gs2_header is not None:
+                raise ValueError('Cannot specify both gs2_header and channel_binding_type')
+            # Client requires channel binding: the gs2 cbind flag becomes "p=<cb-name>".
+            gs2_header = f'p={channel_binding_type}'
 
         self.__nonce = generate_nonce()
         # RFC 5802, Section 5.1: "Before sending the username to the server, the client SHOULD

--- a/truenas_api_client/py_scram/client_first.py
+++ b/truenas_api_client/py_scram/client_first.py
@@ -48,6 +48,11 @@ class ClientFirstMessage:
         if channel_binding_type is not None:
             if not isinstance(channel_binding_type, str):
                 raise TypeError('channel_binding_type must be string if provided')
+            if not channel_binding_type:
+                # A "p=" gs2 cbind flag requires a non-empty cb-name; an empty string
+                # would emit a malformed "p=,," header. Reject it, matching the C
+                # library's scram_build_gs2_header() (rejects empty cb_name).
+                raise ValueError('channel_binding_type must not be empty if provided')
             if gs2_header is not None:
                 raise ValueError('Cannot specify both gs2_header and channel_binding_type')
             # Client requires channel binding: the gs2 cbind flag becomes "p=<cb-name>".

--- a/truenas_api_client/py_scram/verify.py
+++ b/truenas_api_client/py_scram/verify.py
@@ -76,7 +76,11 @@ def verify_server_signature(
     # Get client-final-message-without-proof
     # Reconstruct the channel binding part
     if client_final.channel_binding:
-        gs2_header_str = client_first.gs2_header or 'n,,'
+        # cbind-input = gs2-header + cbind-data (RFC 5802 6). The gs2-header is the cbind
+        # flag plus the empty-authzid separator, exactly as ClientFinalMessage emitted it
+        # (e.g. "p=tls-server-end-point,,"); this must match client_final.py byte-for-byte
+        # or the reconstructed AuthMessage -- and thus signature verification -- will fail.
+        gs2_header_str = (client_first.gs2_header or 'n') + GS2_SEPARATOR
         cb_data = gs2_header_str.encode() + bytes(client_final.channel_binding)
         channel_binding_b64 = b64encode(cb_data).decode()
     else:
@@ -160,7 +164,11 @@ def verify_client_final_message(
     # Get client-final-message-without-proof
     # Reconstruct the channel binding part
     if client_final.channel_binding:
-        gs2_header_str = client_first.gs2_header or 'n,,'
+        # cbind-input = gs2-header + cbind-data (RFC 5802 6). The gs2-header is the cbind
+        # flag plus the empty-authzid separator, exactly as ClientFinalMessage emitted it
+        # (e.g. "p=tls-server-end-point,,"); this must match client_final.py byte-for-byte
+        # or the reconstructed AuthMessage -- and thus signature verification -- will fail.
+        gs2_header_str = (client_first.gs2_header or 'n') + GS2_SEPARATOR
         cb_data = gs2_header_str.encode() + bytes(client_final.channel_binding)
         channel_binding_b64 = b64encode(cb_data).decode()
     else:

--- a/truenas_api_client/scram_impl.py
+++ b/truenas_api_client/scram_impl.py
@@ -124,6 +124,12 @@ ScramError = truenas_pyscram.ScramError
 # Export error codes
 SCRAM_E_AUTH_FAILED = getattr(truenas_pyscram, 'SCRAM_E_AUTH_FAILED', 7)
 
+# Channel binding (RFC 5929 tls-server-end-point). Present on truenas_pyscram >= 0.2.0
+# and on the bundled py_scram fallback; absent on older C extensions, in which case
+# compute_tls_server_end_point is None and callers must skip channel binding.
+CB_TLS_SERVER_END_POINT = getattr(truenas_pyscram, 'CB_TLS_SERVER_END_POINT', 'tls-server-end-point')
+compute_tls_server_end_point = getattr(truenas_pyscram, 'compute_tls_server_end_point', None)
+
 
 class ScramMessageType(StrEnum):
     CLIENT_FIRST_MESSAGE = 'CLIENT_FIRST_MESSAGE'
@@ -188,7 +194,8 @@ class TNScramClient:
     def get_client_first_message(
         self,
         username: str,
-        gs2_header: str | None = None
+        gs2_header: str | None = None,
+        channel_binding_type: str | None = None,
     ) -> ScramMessage:
         """
         Generate the first message of the client-server exchange. We slightly depart
@@ -217,6 +224,8 @@ class TNScramClient:
         }
         if gs2_header is not None:
             kwargs['gs2_header'] = gs2_header
+        if channel_binding_type is not None:
+            kwargs['channel_binding_type'] = channel_binding_type
 
         self.client_first_message = truenas_pyscram.ClientFirstMessage(**kwargs)
         return ScramMessage(


### PR DESCRIPTION
Add SCRAM-PLUS channel binding (RFC 5929 tls-server-end-point) to API-key SCRAM authentication, binding the exchange to the server's TLS certificate so the server can detect a TLS-terminating man-in-the-middle. The binding is computed from the peer certificate read off the live socket (works even with verify_ssl=False); the pure-Python py_scram fallback mirrors truenas_pyscram's computation.

login_with_api_key uses channel binding by default and fails if it cannot be negotiated: over TLS it sends a p=tls-server-end-point gs2 flag; a non-TLS network transport, or a SCRAM backend too old to compute the binding, raises ValueError. The local UNIX socket is exempt, since channel binding is meaningless for local IPC. Pass channel_binding=False -- or the new midclt --no-channel-binding flag -- for an unbound exchange over a plain ws:// connection or against a server that does not support channel binding. SCRAM and channel binding are supported on TrueNAS 26 and later.

Also fix the py_scram fallback (verify.py): the bound cbind-input reconstruction used `gs2_header or 'n,,'`, dropping the ',,' separator after a p= flag, which broke server-signature verification on any channel-bound login when the C extension is unavailable. It now matches ClientFinalMessage byte-for-byte.

Original PR: https://github.com/truenas/api_client/pull/79
