### PR TITLE
NAS-141750 / 27.0.0-BETA.1 / Use `by_alias=True` when dumping pydantic models in JSON serializer

### DIFF
--- a/truenas_api_client/ejson.py
+++ b/truenas_api_client/ejson.py
@@ -64,7 +64,7 @@ class JSONEncoder(json.JSONEncoder):
         elif isinstance(obj, IPv6Interface):
             return {'$ipv6_interface': str(obj)}
         elif BaseModel is not None and isinstance(obj, BaseModel):
-            return obj.model_dump()
+            return obj.model_dump(warnings=False, by_alias=True)
         return super(JSONEncoder, self).default(obj)
 
 


### PR DESCRIPTION
We always use this option when dumping pydantic models explicitly. Let's be consistent here.