### PR TITLE
NAS-141990 / 27.0.0-BETA.1 / api_client: fix midclt login-failure reporting

### DIFF
--- a/tests/test_auth_api_key.py
+++ b/tests/test_auth_api_key.py
@@ -304,7 +304,7 @@ class TestGetKeyMaterialErrors(unittest.TestCase):
     """Test error handling in get_key_material."""
 
     def test_invalid_json_and_ini(self):
-        """Test that invalid JSON and INI raises descriptive error."""
+        """Invalid JSON/INI raises a clear error naming the accepted formats."""
         invalid_data = "this is {not valid json or ini"
 
         with self.assertRaises(ValueError) as ctx:
@@ -312,8 +312,20 @@ class TestGetKeyMaterialErrors(unittest.TestCase):
 
         error_msg = str(ctx.exception)
         self.assertIn("Key material must be either", error_msg)
-        self.assertIn("JSON error:", error_msg)
-        self.assertIn("INI error:", error_msg)
+        # A clean generic message, not ConfigParser's raw error.
+        self.assertNotIn(invalid_data, error_msg)
+
+    def test_malformed_key_material_gives_clean_error(self):
+        """A malformed key (not a raw key or JSON) gets the generic error with no chained cause."""
+        malformed = "1-not+a/valid=key=="  # fails raw pattern, not JSON, not INI
+
+        with self.assertRaises(ValueError) as ctx:
+            get_key_material(malformed)
+
+        self.assertIn("Key material must be either", str(ctx.exception))
+        self.assertNotIn(malformed, str(ctx.exception))
+        # Generic message replaces ConfigParser's, and its chain is suppressed.
+        self.assertIsNone(ctx.exception.__cause__)
 
     def test_empty_string_with_no_dash(self):
         """Test empty string without dash raises error."""

--- a/tests/test_midclt_login_failure.py
+++ b/tests/test_midclt_login_failure.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Regression test: `midclt call` must report a login failure as a failure.
+
+A rejected login previously printed to stdout and exited 0, so shell callers reading the exit
+code or capturing stdout saw a successful, JSON-producing run. It must now write to stderr and
+exit non-zero.
+"""
+import contextlib
+import io
+import sys
+import unittest
+from unittest import mock
+
+import truenas_api_client
+
+
+class TestMidcltLoginFailureExit(unittest.TestCase):
+    def _run_main(self, argv):
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with mock.patch.object(sys, 'argv', argv), \
+                mock.patch.object(truenas_api_client, 'Client') as mock_client, \
+                contextlib.redirect_stdout(stdout), \
+                contextlib.redirect_stderr(stderr):
+            # `with Client(...) as c:` -> c is the entered context manager. Make login fail.
+            mock_client.return_value.__exit__.return_value = False  # do not swallow SystemExit
+            c = mock_client.return_value.__enter__.return_value
+            c.login_with_password.side_effect = ValueError('Invalid username or password')
+            c.login_with_api_key.side_effect = ValueError('Invalid API key')
+            with self.assertRaises(SystemExit) as ctx:
+                truenas_api_client.main()
+        return ctx.exception.code, stdout.getvalue(), stderr.getvalue()
+
+    def test_password_login_failure_exits_nonzero_on_stderr(self):
+        code, out, err = self._run_main(
+            ['midclt', '-u', 'ws://h/api/current', '-U', 'admin', '-P', 'wrong', 'call', 'system.info']
+        )
+        self.assertEqual(code, 1)
+        self.assertIn('Failed to login', err)
+        self.assertNotIn('Failed to login', out)
+
+    def test_api_key_login_failure_exits_nonzero_on_stderr(self):
+        code, out, err = self._run_main(
+            ['midclt', '-u', 'ws://h/api/current', '-K', '1-badkey', 'call', 'system.info']
+        )
+        self.assertEqual(code, 1)
+        self.assertIn('Failed to login', err)
+        self.assertNotIn('Failed to login', out)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -1300,8 +1300,8 @@ def main():
                             channel_binding=not args.no_channel_binding,
                         )
                 except Exception as e:
-                    print("Failed to login: ", e)
-                    sys.exit(0)
+                    print("Failed to login: ", e, file=sys.stderr)
+                    sys.exit(1)
                 try:
                     kwargs = {}
                     if args.timeout:

--- a/truenas_api_client/auth_api_key.py
+++ b/truenas_api_client/auth_api_key.py
@@ -134,15 +134,19 @@ def get_key_material(key: str) -> KeyData:
     # Try parsing as structured data (JSON or INI format)
     try:
         data = loads(key)
-    except JSONDecodeError as json_err:
+    except JSONDecodeError:
         try:
             data = _parse_ini_config(key)
-        except (ConfigParserError, KeyError, ValueError) as ini_err:
+        except ConfigParserError:
+            # When key material isn't a raw key or JSON, the ConfigParser fallback raises
+            # MissingSectionHeaderError, whose message is confusing rather than useful guidance.
+            # Replace it with a clear message naming the accepted formats, and suppress the chain
+            # so that internal error isn't re-surfaced. ValueError/KeyError raised by
+            # _parse_ini_config itself are useful diagnostics and are allowed to propagate.
             raise ValueError(
-                f'Key material must be either a raw API key (format: <id>-<key>), '
-                f'valid JSON, or valid INI/ConfigParser format. '
-                f'JSON error: {json_err}. INI error: {ini_err}'
-            ) from ini_err
+                'Key material must be either a raw API key (format: <id>-<key>), '
+                'valid JSON, or valid INI/ConfigParser format'
+            ) from None
 
     # Construct the appropriate type based on the fields present
     try:


### PR DESCRIPTION
- Print login failures to stderr and exit 1 instead of stdout/exit 0, which made shell callers reading the exit code or stdout see success.
- Replace the confusing ConfigParser error raised when key material isn't a raw key or JSON with a clear message naming the accepted formats. Diagnostics raised by _parse_ini_config itself are unchanged.