### PR TITLE
NAS-141992 / 27.0.0-BETA.1 / api_client: fix / harden job disconnect handling

### DIFF
--- a/tests/test_job_disconnect.py
+++ b/tests/test_job_disconnect.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Job.result() and the connection-close error broadcast, for jobs that don't finish normally.
+
+Both the current JSON-RPC client and the legacy client share this path, so both are covered.
+"""
+import errno
+import unittest
+from collections import defaultdict
+from threading import Event, Lock
+
+from truenas_api_client import JSONRPCClient, Job
+from truenas_api_client.legacy import LegacyClient, Job as LegacyJob
+from truenas_api_client.exc import ClientException
+
+
+def _bare(cls, **attrs):
+    """Build an instance without running __init__ (which would open a connection)."""
+    obj = object.__new__(cls)
+    for name, value in attrs.items():
+        setattr(obj, name, value)
+    return obj
+
+
+def _current():
+    return _bare(JSONRPCClient, _calls={}, _jobs=defaultdict(dict), _jobs_lock=Lock())
+
+
+def _legacy():
+    return _bare(LegacyClient, _calls={}, _jobs=defaultdict(dict), _jobs_lock=Lock(),
+                 _connected=Event(), _closed=Event(), _connection_error=None)
+
+
+class _MutatingEvent(Event):
+    """Event whose set() inserts into `jobs`, simulating a job arriving during iteration."""
+
+    def __init__(self, jobs):
+        super().__init__()
+        self._jobs = jobs
+
+    def set(self):
+        self._jobs['inserted-during-iteration'] = {}
+        super().set()
+
+
+class TestAbortedJobResult(unittest.TestCase):
+    """An aborted job (no exc_info) reports failure via ClientException."""
+
+    def _check(self, client, job_cls):
+        job = job_cls(client, 'j1')
+        client._jobs['j1'].update(state='ABORTED', exc_info=None, exception=None, error=None)
+        client._jobs['j1']['__ready'].set()
+        with self.assertRaises(ClientException):
+            job.result()
+
+    def test_current(self):
+        self._check(_current(), Job)
+
+    def test_legacy(self):
+        self._check(_legacy(), LegacyJob)
+
+
+class TestJobResultAfterDisconnect(unittest.TestCase):
+    """A job left unfinished by a dropped connection reports failure via ClientException."""
+
+    def test_current(self):
+        c = _current()
+        job = Job(c, 'j1')
+        c._broadcast_error(ClientException('closed', errno.ECONNABORTED))
+        with self.assertRaises(ClientException):
+            job.result()
+
+    def test_legacy(self):
+        c = _legacy()
+        job = LegacyJob(c, 'j1')
+        c.on_close(1006)
+        with self.assertRaises(ClientException):
+            job.result()
+
+
+class TestBroadcastConcurrentModification(unittest.TestCase):
+    """The close-time broadcast tolerates the jobs dict being resized during iteration."""
+
+    def test_current(self):
+        c = _current()
+        c._jobs['j1'] = {'__ready': _MutatingEvent(c._jobs)}
+        c._broadcast_error(ClientException('closed', errno.ECONNABORTED))
+        self.assertIn('inserted-during-iteration', c._jobs)
+
+    def test_legacy(self):
+        c = _legacy()
+        c._jobs['j1'] = {'__ready': _MutatingEvent(c._jobs)}
+        c.on_close(1006)
+        self.assertIn('inserted-during-iteration', c._jobs)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_job_disconnect.py
+++ b/tests/test_job_disconnect.py
@@ -10,7 +10,7 @@ from threading import Event, Lock
 
 from truenas_api_client import JSONRPCClient, Job
 from truenas_api_client.legacy import LegacyClient, Job as LegacyJob
-from truenas_api_client.exc import ClientException
+from truenas_api_client.exc import ClientException, ValidationErrors
 
 
 def _bare(cls, **attrs):
@@ -50,6 +50,27 @@ class TestAbortedJobResult(unittest.TestCase):
         client._jobs['j1'].update(state='ABORTED', exc_info=None, exception=None, error=None)
         client._jobs['j1']['__ready'].set()
         with self.assertRaises(ClientException):
+            job.result()
+
+    def test_current(self):
+        self._check(_current(), Job)
+
+    def test_legacy(self):
+        self._check(_legacy(), LegacyJob)
+
+
+class TestValidationJobResult(unittest.TestCase):
+    """A validation-failed job surfaces as ValidationErrors, not a generic ClientException."""
+
+    def _check(self, client, job_cls):
+        job = job_cls(client, 'j1')
+        client._jobs['j1'].update(
+            state='FAILED',
+            exc_info={'type': 'VALIDATION', 'repr': 'ValidationErrors',
+                      'extra': [('field', 'is required', errno.EINVAL)]},
+            exception='validation failed', error='validation failed')
+        client._jobs['j1']['__ready'].set()
+        with self.assertRaises(ValidationErrors):
             job.result()
 
     def test_current(self):

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -376,20 +376,28 @@ class Job:
         job = self.client._jobs.pop(self.job_id, None)
         if job is None:
             raise ClientException('No job event was received.')
-        if job['state'] != 'SUCCESS':
-            if job['exc_info'] and job['exc_info']['type'] == 'VALIDATION':
-                raise ValidationErrors(job['exc_info']['extra'] or [])
+        state = job.get('state')
+        if state == 'SUCCESS':
+            return job['result']
+
+        exc_info = job.get('exc_info')
+        if exc_info and exc_info['type'] == 'VALIDATION':
+            raise ValidationErrors(exc_info['extra'] or [])
+
+        if exc_info:
             raise ClientException(
                 job['error'],
                 trace={
-                    'class': job['exc_info']['type'],
+                    'class': exc_info['type'],
                     'frames': [],
                     'formatted': job['exception'],
-                    'repr': job['exc_info'].get('repr', job['exception'].splitlines()[-1]),
+                    'repr': exc_info.get('repr') or job['exception'].splitlines()[-1],
                 },
-                extra=job['exc_info']['extra']
+                extra=exc_info['extra'],
             )
-        return job['result']
+
+        # Aborted or interrupted jobs have no exc_info to build a trace from.
+        raise ClientException(job.get('error') or f'Job {self.job_id} did not succeed (state={state!r})')
 
 
 class _EventCallbackProtocol(Protocol):
@@ -696,13 +704,17 @@ class JSONRPCClient:
                 call.returned.set()
                 self._unregister_call(call)
 
-        for job in self._jobs.values():
+        # Snapshot: _jobs can be resized concurrently (a woken result() pops, the reader inserts).
+        for job in list(self._jobs.values()):
             event = job.get('__ready')
             if event is None:
                 event = job['__ready'] = Event()
 
             if not event.is_set():
                 error_repr = repr(error)
+                # The connection dropped, so the real outcome is unknown (the job may still be
+                # running server-side); just mark it non-SUCCESS for Job.result().
+                job['state'] = 'UNKNOWN'
                 job['error'] = error_repr
                 job['exception'] = error_repr
                 job['exc_info'] = {

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -381,10 +381,9 @@ class Job:
             return job['result']
 
         exc_info = job.get('exc_info')
-        if exc_info and exc_info['type'] == 'VALIDATION':
-            raise ValidationErrors(exc_info['extra'] or [])
-
         if exc_info:
+            if exc_info['type'] == 'VALIDATION':
+                raise ValidationErrors(exc_info['extra'] or [])
             raise ClientException(
                 job['error'],
                 trace={

--- a/truenas_api_client/legacy.py
+++ b/truenas_api_client/legacy.py
@@ -181,11 +181,9 @@ class Job:
             return job['result']
 
         exc_info = job.get('exc_info')
-        if exc_info and exc_info['type'] == 'VALIDATION':
-            raise ValidationErrors(exc_info['extra'] or [])
         if exc_info:
-            # middlewared sets exc_info, exception and error together (job.py set_exception), so
-            # when exc_info is present these are non-None strings.
+            if exc_info['type'] == 'VALIDATION':
+                raise ValidationErrors(exc_info['extra'] or [])
             raise ClientException(
                 job['error'],
                 trace={

--- a/truenas_api_client/legacy.py
+++ b/truenas_api_client/legacy.py
@@ -176,20 +176,28 @@ class Job:
         job = self.client._jobs.pop(self.job_id, None)
         if job is None:
             raise ClientException('No job event was received.')
-        if job['state'] != 'SUCCESS':
-            if job['exc_info'] and job['exc_info']['type'] == 'VALIDATION':
-                raise ValidationErrors(job['exc_info']['extra'])
+        state = job.get('state')
+        if state == 'SUCCESS':
+            return job['result']
+
+        exc_info = job.get('exc_info')
+        if exc_info and exc_info['type'] == 'VALIDATION':
+            raise ValidationErrors(exc_info['extra'] or [])
+        if exc_info:
+            # middlewared sets exc_info, exception and error together (job.py set_exception), so
+            # when exc_info is present these are non-None strings.
             raise ClientException(
                 job['error'],
                 trace={
-                    'class': job['exc_info']['type'],
+                    'class': exc_info['type'],
                     'frames': [],
                     'formatted': job['exception'],
-                    'repr': job['exc_info'].get('repr', job['exception'].splitlines()[-1]),
+                    'repr': exc_info.get('repr') or job['exception'].splitlines()[-1],
                 },
-                extra=job['exc_info']['extra']
+                extra=exc_info['extra'],
             )
-        return job['result']
+        # Aborted or interrupted jobs have no exc_info to build a trace from.
+        raise ClientException(job.get('error') or f'Job {self.job_id} did not succeed (state={state!r})')
 
 
 class LegacyClient:
@@ -333,18 +341,22 @@ class LegacyClient:
         self._connection_error = error
         self._connected.set()
 
-        for call in self._calls.values():
+        # Snapshot: _calls/_jobs can be resized concurrently (a woken waiter pops, the reader inserts).
+        for call in list(self._calls.values()):
             if not call.returned.is_set():
                 call.errno = errno.ECONNABORTED
                 call.error = error
                 call.returned.set()
 
-        for job in self._jobs.values():
+        for job in list(self._jobs.values()):
             event = job.get('__ready')
             if event is None:
                 event = job['__ready'] = Event()
 
             if not event.is_set():
+                # The connection dropped, so the real outcome is unknown (the job may still be
+                # running server-side); just mark it non-SUCCESS for Job.result().
+                job['state'] = 'UNKNOWN'
                 job['error'] = error
                 job['exception'] = error
                 job['exc_info'] = {


### PR DESCRIPTION
Job.result() and the close-time error broadcast mishandled jobs that don't finish normally:

- An aborted job carries no exc_info, so Job.result() raised TypeError dereferencing job['exc_info']['type']. Only build the trace when exc_info is present.
- A job completed only by the broadcast had no 'state', so Job.result() raised KeyError on job['state']. Read state with .get(), and have the broadcast set a terminal state.
- The broadcast iterated the jobs dict directly; setting a job's event can wake a Job.result() thread that pops from it (and the reader thread may insert), changing its size mid-iteration and raising RuntimeError. Snapshot with list(), as the calls loop already does.

Same fixes in the legacy client (Job.result and on_close, whose calls loop was also unsnapshotted).