### PR TITLE
NAS-141999 / 27.0.0-BETA.1 / api_client: align py_scram fallback with the truenas_scram C reference

### DIFF
--- a/tests/scram/test_py_scram.py
+++ b/tests/scram/test_py_scram.py
@@ -189,7 +189,8 @@ class TestServerFirstMessage(unittest.TestCase):
 
     def test_from_rfc_string(self):
         """Test parsing ServerFirstMessage from RFC string."""
-        rfc_string = "r=Y2xpZW50bm9uY2U=,s=c2FsdA==,i=50000"
+        nonce = b64encode(b'\x22' * 64).decode()  # combined client+server nonce is 64 bytes
+        rfc_string = f"r={nonce},s=c2FsdA==,i=50000"
         msg = py_scram.ServerFirstMessage(rfc_string=rfc_string)
 
         self.assertEqual(str(msg), rfc_string)
@@ -311,7 +312,9 @@ class TestClientFinalMessage(unittest.TestCase):
 
     def test_from_rfc_string(self):
         """Test parsing ClientFinalMessage from RFC string."""
-        rfc_string = "c=biws,r=Y2xpZW50bm9uY2U=,p=cHJvb2Y="
+        nonce = b64encode(b'\x22' * 64).decode()
+        proof = b64encode(b'\x33' * 64).decode()
+        rfc_string = f"c=biws,r={nonce},p={proof}"
         client_final = py_scram.ClientFinalMessage(rfc_string=rfc_string)
 
         self.assertEqual(str(client_final), rfc_string)
@@ -492,6 +495,70 @@ class TestVerificationFunctions(unittest.TestCase):
             )
 
         self.assertEqual(ctx.exception.code, py_scram.SCRAM_E_AUTH_FAILED)
+
+
+class TestCLibraryCongruence(unittest.TestCase):
+    """Behaviors that must match the truenas_scram C reference (src/scram)."""
+
+    def setUp(self):
+        self.salt = py_scram.CryptoDatum(b"test_salt_16bytes")
+        self.client_first = py_scram.ClientFirstMessage(username="testuser")
+        self.server_first = py_scram.ServerFirstMessage(
+            client_first=self.client_first, salt=self.salt, iterations=100000)
+        salted = py_scram.scram_hi(py_scram.CryptoDatum(b"pw"), self.salt, 100000)
+        self.client_key = py_scram.scram_create_client_key(salted)
+        self.stored_key = py_scram.scram_create_stored_key(self.client_key)
+
+    def test_username_with_comma_or_equals_rejected(self):
+        """The C rejects ',' and '=' in usernames (scram_create_client_first_message)."""
+        for bad in ("user,name", "user=name"):
+            with self.subTest(username=bad):
+                with self.assertRaises(ValueError):
+                    py_scram.ClientFirstMessage(username=bad)
+
+    def test_channel_binding_c_value(self):
+        """c= is base64(gs2-header + ',,' + cbind-data), as the C serializer builds it."""
+        cb = py_scram.CryptoDatum(b'\xaa' * 32)
+        cfirst = py_scram.ClientFirstMessage(
+            username="testuser", channel_binding_type="tls-server-end-point")
+        sfirst = py_scram.ServerFirstMessage(
+            client_first=cfirst, salt=self.salt, iterations=100000)
+        cfinal = py_scram.ClientFinalMessage(
+            client_first=cfirst, server_first=sfirst,
+            client_key=self.client_key, stored_key=self.stored_key, channel_binding=cb)
+        c_b64 = str(cfinal).split(',', 1)[0][len('c='):]
+        self.assertEqual(b64decode(c_b64), b'p=tls-server-end-point,,' + b'\xaa' * 32)
+
+    def test_p_flag_requires_channel_binding(self):
+        """gs2 'p' flag without binding data is rejected (check_gs2_cb_consistency)."""
+        cfirst = py_scram.ClientFirstMessage(
+            username="testuser", channel_binding_type="tls-server-end-point")
+        sfirst = py_scram.ServerFirstMessage(
+            client_first=cfirst, salt=self.salt, iterations=100000)
+        with self.assertRaises(ValueError):
+            py_scram.ClientFinalMessage(
+                client_first=cfirst, server_first=sfirst,
+                client_key=self.client_key, stored_key=self.stored_key)
+
+    def test_channel_binding_requires_p_flag(self):
+        """Binding data with a non-'p' flag is rejected (check_gs2_cb_consistency)."""
+        with self.assertRaises(ValueError):
+            py_scram.ClientFinalMessage(
+                client_first=self.client_first, server_first=self.server_first,
+                client_key=self.client_key, stored_key=self.stored_key,
+                channel_binding=py_scram.CryptoDatum(b'\xaa' * 32))
+
+    def test_server_first_rejects_wrong_nonce_size(self):
+        """The C parser accepts only 32- or 64-byte nonces (scram_parse_nonce)."""
+        short = b64encode(b'\x22' * 11).decode()
+        with self.assertRaises(py_scram.ScramError):
+            py_scram.ServerFirstMessage(rfc_string=f"r={short},s=c2FsdA==,i=50000")
+
+    def test_server_first_rejects_low_iterations(self):
+        """The C parser enforces the minimum iteration count (scram_parse_iteration_cnt)."""
+        nonce = b64encode(b'\x22' * 64).decode()
+        with self.assertRaises(py_scram.ScramError):
+            py_scram.ServerFirstMessage(rfc_string=f"r={nonce},s=c2FsdA==,i=100")
 
 
 class TestCryptoFunctions(unittest.TestCase):

--- a/truenas_api_client/py_scram/client_final.py
+++ b/truenas_api_client/py_scram/client_final.py
@@ -3,8 +3,8 @@
 
 from base64 import b64encode, b64decode
 
-from .scram_crypto import CryptoDatum, scram_hmac_sha512, scram_xor_bytes
-from .common import GS2_SEPARATOR, GS2_NO_CHANNEL_BINDING
+from .scram_crypto import CryptoDatum, scram_hmac_sha512, scram_xor_bytes, SCRAM_NONCE_SIZE, SHA512_DIGEST_SIZE
+from .common import GS2_SEPARATOR
 from .client_first import ClientFirstMessage
 from .server_first import ServerFirstMessage
 
@@ -113,17 +113,22 @@ class ClientFinalMessage:
             self.__channel_binding = channel_binding
             self.__gs2_header = client_first.gs2_header
 
-            # Prepare channel binding for message
-            if channel_binding:
-                # cbind-input = gs2-header + cbind-data (RFC 5802 6). The gs2-header is the
-                # cbind flag plus the empty-authzid separator exactly as it appears in
-                # client-first, e.g. "p=tls-server-end-point,,".
-                gs2_header_str = (client_first.gs2_header or 'n') + GS2_SEPARATOR
-                cb_data = gs2_header_str.encode() + bytes(channel_binding)
-                channel_binding_b64 = b64encode(cb_data).decode()
-            else:
-                # No channel binding - use standard GS2_NO_CHANNEL_BINDING
-                channel_binding_b64 = GS2_NO_CHANNEL_BINDING
+            # Validate the gs2 flag / channel-binding combination (RFC 5802 6), matching the C
+            # library's check_gs2_cb_consistency: a 'p' flag requires binding data, and any other
+            # flag ('n'/'y', or no header) must not carry any.
+            gs2_flag = (client_first.gs2_header or 'n')[0]
+            have_cb = bool(channel_binding)
+            if gs2_flag == 'p' and not have_cb:
+                raise ValueError("gs2 channel-binding flag 'p' requires channel binding data")
+            if gs2_flag != 'p' and have_cb:
+                raise ValueError("channel binding data provided but gs2 flag is not 'p'")
+
+            # c= is base64(cbind-input) where cbind-input = gs2-header + ",," + [cbind-data]
+            # (RFC 5802 7); the gs2-header defaults to "n". Mirrors the C library's
+            # scram_serialize_client_final_message so both backends emit the same c= value.
+            gs2_header_str = (client_first.gs2_header or 'n') + GS2_SEPARATOR
+            cb_data = gs2_header_str.encode() + (bytes(channel_binding) if have_cb else b'')
+            channel_binding_b64 = b64encode(cb_data).decode()
 
             # Compute auth message
             auth_message = self.__compute_auth_message(client_first, server_first, channel_binding_b64)
@@ -183,6 +188,13 @@ class ClientFinalMessage:
                 client_proof_bytes = None
         except Exception as e:
             raise ValueError(f'Invalid base64 encoding in client final message: {e}')
+
+        # Match the C parser (scram_attr_parse): the nonce is a 32- or 64-byte value and the
+        # client proof, when present, is a SHA-512 digest.
+        if len(nonce_bytes) not in (SCRAM_NONCE_SIZE, SCRAM_NONCE_SIZE * 2):
+            raise ValueError(f'{len(nonce_bytes)}: unexpected nonce size')
+        if client_proof_bytes is not None and len(client_proof_bytes) != SHA512_DIGEST_SIZE:
+            raise ValueError(f'{len(client_proof_bytes)}: unexpected client proof size')
 
         self.__nonce = CryptoDatum(nonce_bytes)
         self.__channel_binding = CryptoDatum(channel_binding_bytes) if channel_binding_bytes else None

--- a/truenas_api_client/py_scram/client_first.py
+++ b/truenas_api_client/py_scram/client_first.py
@@ -39,6 +39,12 @@ class ClientFirstMessage:
         if not isinstance(username, str):
             raise TypeError('Username must be string')
 
+        # SCRAM messages are comma-separated and use '=' for the "=2C"/"=3D" username escapes
+        # (RFC 5802 5.1) that this library does not emit. Reject both characters up front,
+        # matching the C library's scram_create_client_first_message().
+        if ',' in username or '=' in username:
+            raise ValueError("username must not contain ',' or '='")
+
         if not isinstance(api_key_id, int):
             raise TypeError('API key ID must be an integer')
 

--- a/truenas_api_client/py_scram/scram_crypto.py
+++ b/truenas_api_client/py_scram/scram_crypto.py
@@ -25,6 +25,8 @@ __all__ = [
     'SCRAM_MIN_ITERS',
     'SCRAM_DEFAULT_ITERS',
     'SCRAM_NONCE_SIZE',
+    'SCRAM_MAX_SALT_SZ',
+    'SHA512_DIGEST_SIZE',
 ]
 
 
@@ -33,6 +35,8 @@ SCRAM_MAX_ITERS = 5000000
 SCRAM_MIN_ITERS = 50000
 SCRAM_DEFAULT_ITERS = 500000
 SCRAM_NONCE_SIZE = 32
+SCRAM_MAX_SALT_SZ = 1024  # salt length cap enforced by the C parser (scram_attr_parse.c)
+SHA512_DIGEST_SIZE = 64   # SHA-512 output length; SCRAM proofs/signatures/keys are this size
 
 
 class CryptoDatum(bytes):

--- a/truenas_api_client/py_scram/server_first.py
+++ b/truenas_api_client/py_scram/server_first.py
@@ -3,7 +3,9 @@
 
 from base64 import b64encode, b64decode
 
-from .scram_crypto import CryptoDatum, generate_nonce, SCRAM_MAX_ITERS
+from .scram_crypto import (
+    CryptoDatum, generate_nonce, SCRAM_MAX_ITERS, SCRAM_MIN_ITERS, SCRAM_NONCE_SIZE, SCRAM_MAX_SALT_SZ,
+)
 from .client_first import ClientFirstMessage
 from .error import ScramError, SCRAM_E_INVALID_REQUEST
 
@@ -92,10 +94,10 @@ class ServerFirstMessage:
         if nonce_b64 is None or salt_b64 is None or iterations is None:
             raise ValueError('Missing required fields in server first message')
 
-        # Validate iterations (like C extension does)
-        if iterations > SCRAM_MAX_ITERS:
+        # Validate iterations against the same bounds as the C parser (scram_parse_iteration_cnt).
+        if iterations < SCRAM_MIN_ITERS or iterations > SCRAM_MAX_ITERS:
             raise ScramError(
-                f'{iterations}: exceeds maximum of {SCRAM_MAX_ITERS}',
+                f'{iterations}: iteration count outside [{SCRAM_MIN_ITERS}, {SCRAM_MAX_ITERS}]',
                 SCRAM_E_INVALID_REQUEST
             )
 
@@ -104,6 +106,19 @@ class ServerFirstMessage:
             salt_bytes = b64decode(salt_b64)
         except Exception as e:
             raise ValueError(f'Invalid base64 encoding in server first message: {e}')
+
+        # The C parser accepts only a 32- or 64-byte nonce and caps the salt length; match both
+        # (scram_parse_nonce / scram_parse_b64_datum in scram_attr_parse.c).
+        if len(nonce_bytes) not in (SCRAM_NONCE_SIZE, SCRAM_NONCE_SIZE * 2):
+            raise ScramError(
+                f'{len(nonce_bytes)}: unexpected nonce size',
+                SCRAM_E_INVALID_REQUEST
+            )
+        if len(salt_bytes) > SCRAM_MAX_SALT_SZ:
+            raise ScramError(
+                f'{len(salt_bytes)}: salt exceeds maximum of {SCRAM_MAX_SALT_SZ}',
+                SCRAM_E_INVALID_REQUEST
+            )
 
         self.__nonce = CryptoDatum(nonce_bytes)
         self.__salt = CryptoDatum(salt_bytes)


### PR DESCRIPTION
The pure-Python py_scram fallback (used when the truenas_pyscram C extension is unavailable) diverged from the C library in a few places after channel binding support was added to the C library. Match it so both backends behave identically:

- client-first: reject usernames containing ',' or '=', which the C rejects rather than escaping (scram_create_client_first_message).
- client-final: build c= as base64(gs2-header + ",," + cbind-data) for every flag, and reject inconsistent gs2-flag/channel-binding combinations (scram_serialize_client_final_message, check_gs2_cb_consistency). The no-binding case still emits "biws".
- server-first parse: reject a nonce that is not 32 or 64 bytes, enforce the minimum iteration count, and cap the salt length (scram_attr_parse).
- client-final parse: reject a wrong-size nonce or client proof (scram_attr_parse).

server-final parse is left unchanged: the C does not validate the signature size there either; a bad signature fails the later verification.

NOTE: this does not impact TrueNAS consumers, but may impact users independently installing this library on non-TrueNAS systems.