### PR TITLE
NAS-141991 / 26.0.0-RC.1 / api_client: raise when reserved_ports is combined with a wss:// URI (by anodos325)

### DIFF
--- a/tests/test_reserved_ports_tls.py
+++ b/tests/test_reserved_ports_tls.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
-"""Regression tests: reserved_ports must never silently downgrade a wss:// URI to plaintext.
+"""reserved_ports only supports plaintext ws://, so connect() must refuse any other scheme.
 
-The reserved-port connection path opens a raw AF_INET socket and hands WebSocketApp a plaintext
-dummy ws:// URL, so it never negotiates TLS. Combining it with a wss:// URI used to connect in
-cleartext while ignoring verify_ssl; it must now fail closed instead. Both the modern JSON-RPC
-client and the legacy client share this path, so both are covered here.
+The reserved-port path opens a raw AF_INET socket and hands WebSocketApp a plaintext dummy
+ws:// URL; it never negotiates TLS. Rather than connect a wss:// URI in cleartext (or attempt
+some other scheme it cannot handle), connect() requires an explicit ws:// URI. The modern
+JSON-RPC client and the legacy client share this path, so both are covered here.
 """
 import sys
 import unittest
@@ -18,12 +18,12 @@ WS_CLIENT_CLASSES = (WSClient, LegacyWSClient)
 
 
 class _ReachedBind(Exception):
-    """Sentinel: raised in place of _bind_to_reserved_port to prove the TLS guard was passed."""
+    """Sentinel: raised in place of _bind_to_reserved_port to prove the scheme guard was passed."""
 
 
-class TestReservedPortsTLS(unittest.TestCase):
+class TestReservedPortsScheme(unittest.TestCase):
     def test_wss_uri_is_refused(self):
-        """wss:// + reserved_ports raises ClientException instead of downgrading to plaintext."""
+        """wss:// + reserved_ports raises rather than connecting in plaintext."""
         for cls in WS_CLIENT_CLASSES:
             with self.subTest(client=cls.__module__):
                 ws = cls('wss://nas.example.com/api/current', client=None, reserved_ports=True)
@@ -31,8 +31,8 @@ class TestReservedPortsTLS(unittest.TestCase):
                     ws.connect()
                 self.assertIn('reserved_ports', str(ctx.exception))
 
-    def test_wss_refused_even_with_verify_ssl_false(self):
-        """The refusal keys off the wss:// scheme, so verify_ssl=False cannot re-enable the downgrade."""
+    def test_wss_refused_regardless_of_verify_ssl(self):
+        """The guard is purely by scheme, so verify_ssl=False does not let a wss:// URI through."""
         for cls in WS_CLIENT_CLASSES:
             with self.subTest(client=cls.__module__):
                 ws = cls('wss://nas.example.com/api/current', client=None, reserved_ports=True,
@@ -40,8 +40,17 @@ class TestReservedPortsTLS(unittest.TestCase):
                 with self.assertRaises(ClientException):
                     ws.connect()
 
+    def test_non_ws_scheme_is_refused(self):
+        """Any scheme other than ws:// (e.g. http://) is refused, not only wss://."""
+        for cls in WS_CLIENT_CLASSES:
+            with self.subTest(client=cls.__module__):
+                ws = cls('http://nas.example.com:6000/api/current', client=None, reserved_ports=True)
+                with self.assertRaises(ClientException) as ctx:
+                    ws.connect()
+                self.assertIn('reserved_ports', str(ctx.exception))
+
     def test_plaintext_ws_passes_the_guard(self):
-        """ws:// + reserved_ports (the failover use case) is still allowed through to the bind step."""
+        """ws:// + reserved_ports (the failover use case) is allowed through to the bind step."""
         for cls in WS_CLIENT_CLASSES:
             with self.subTest(client=cls.__module__):
                 ws = cls('ws://nas.example.com:6000/api/current', client=None, reserved_ports=True)

--- a/tests/test_reserved_ports_tls.py
+++ b/tests/test_reserved_ports_tls.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Regression tests: reserved_ports must never silently downgrade a wss:// URI to plaintext.
+
+The reserved-port connection path opens a raw AF_INET socket and hands WebSocketApp a plaintext
+dummy ws:// URL, so it never negotiates TLS. Combining it with a wss:// URI used to connect in
+cleartext while ignoring verify_ssl; it must now fail closed instead. Both the modern JSON-RPC
+client and the legacy client share this path, so both are covered here.
+"""
+import sys
+import unittest
+from unittest import mock
+
+from truenas_api_client import WSClient
+from truenas_api_client.legacy import WSClient as LegacyWSClient
+from truenas_api_client.exc import ClientException
+
+WS_CLIENT_CLASSES = (WSClient, LegacyWSClient)
+
+
+class _ReachedBind(Exception):
+    """Sentinel: raised in place of _bind_to_reserved_port to prove the TLS guard was passed."""
+
+
+class TestReservedPortsTLS(unittest.TestCase):
+    def test_wss_uri_is_refused(self):
+        """wss:// + reserved_ports raises ClientException instead of downgrading to plaintext."""
+        for cls in WS_CLIENT_CLASSES:
+            with self.subTest(client=cls.__module__):
+                ws = cls('wss://nas.example.com/api/current', client=None, reserved_ports=True)
+                with self.assertRaises(ClientException) as ctx:
+                    ws.connect()
+                self.assertIn('reserved_ports', str(ctx.exception))
+
+    def test_wss_refused_even_with_verify_ssl_false(self):
+        """The refusal keys off the wss:// scheme, so verify_ssl=False cannot re-enable the downgrade."""
+        for cls in WS_CLIENT_CLASSES:
+            with self.subTest(client=cls.__module__):
+                ws = cls('wss://nas.example.com/api/current', client=None, reserved_ports=True,
+                         verify_ssl=False)
+                with self.assertRaises(ClientException):
+                    ws.connect()
+
+    def test_plaintext_ws_passes_the_guard(self):
+        """ws:// + reserved_ports (the failover use case) is still allowed through to the bind step."""
+        for cls in WS_CLIENT_CLASSES:
+            with self.subTest(client=cls.__module__):
+                ws = cls('ws://nas.example.com:6000/api/current', client=None, reserved_ports=True)
+                module = sys.modules[cls.__module__]
+                # Avoid real network I/O: fake the socket and stop at the bind step. If the guard
+                # wrongly rejected ws://, we'd see ClientException instead of _ReachedBind.
+                with mock.patch.object(module.socket, 'socket', return_value=mock.MagicMock()), \
+                        mock.patch.object(ws, '_bind_to_reserved_port', side_effect=_ReachedBind):
+                    with self.assertRaises(_ReachedBind):
+                        ws.connect()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -155,13 +155,13 @@ class WSClient:
             self.socket.connect(self.url.removeprefix(UNIX_SOCKET_PREFIX))
             app_url = DUMMY_HOSTNAME
         elif self.reserved_ports:
-            # The reserved-port path connects a raw socket and hands WebSocketApp a plaintext
-            # dummy ws:// URL below, so TLS is never negotiated here. A wss:// URI would therefore
-            # be silently downgraded to cleartext (verify_ssl is ignored); fail closed instead.
-            if urllib.parse.urlparse(self.url).scheme == 'wss':
+            # reserved_ports uses a raw socket and never negotiates TLS, so it only supports a
+            # plaintext ws:// URI. Require that scheme explicitly rather than, for example,
+            # connecting a wss:// URI in cleartext.
+            scheme = urllib.parse.urlparse(self.url).scheme
+            if scheme != 'ws':
                 raise ClientException(
-                    'reserved_ports connections do not support TLS; a wss:// URI cannot be used '
-                    'with reserved_ports=True (would downgrade the connection to plaintext)'
+                    f'reserved_ports connections require a ws:// URI, got {scheme!r}'
                 )
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.settimeout(10)

--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -155,6 +155,14 @@ class WSClient:
             self.socket.connect(self.url.removeprefix(UNIX_SOCKET_PREFIX))
             app_url = DUMMY_HOSTNAME
         elif self.reserved_ports:
+            # The reserved-port path connects a raw socket and hands WebSocketApp a plaintext
+            # dummy ws:// URL below, so TLS is never negotiated here. A wss:// URI would therefore
+            # be silently downgraded to cleartext (verify_ssl is ignored); fail closed instead.
+            if urllib.parse.urlparse(self.url).scheme == 'wss':
+                raise ClientException(
+                    'reserved_ports connections do not support TLS; a wss:// URI cannot be used '
+                    'with reserved_ports=True (would downgrade the connection to plaintext)'
+                )
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.settimeout(10)
             self._bind_to_reserved_port()

--- a/truenas_api_client/legacy.py
+++ b/truenas_api_client/legacy.py
@@ -45,6 +45,14 @@ class WSClient:
             self.socket.connect(self.url.removeprefix(unix_socket_prefix))
             app_url = "ws://localhost/websocket"  # Adviced by official docs to use dummy hostname
         elif self.reserved_ports:
+            # The reserved-port path connects a raw socket and hands WebSocketApp a plaintext
+            # dummy ws:// URL below, so TLS is never negotiated here. A wss:// URI would therefore
+            # be silently downgraded to cleartext (verify_ssl is ignored); fail closed instead.
+            if urllib.parse.urlparse(self.url).scheme == 'wss':
+                raise ClientException(
+                    'reserved_ports connections do not support TLS; a wss:// URI cannot be used '
+                    'with reserved_ports=True (would downgrade the connection to plaintext)'
+                )
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.settimeout(10)
             self._bind_to_reserved_port()

--- a/truenas_api_client/legacy.py
+++ b/truenas_api_client/legacy.py
@@ -45,13 +45,13 @@ class WSClient:
             self.socket.connect(self.url.removeprefix(unix_socket_prefix))
             app_url = "ws://localhost/websocket"  # Adviced by official docs to use dummy hostname
         elif self.reserved_ports:
-            # The reserved-port path connects a raw socket and hands WebSocketApp a plaintext
-            # dummy ws:// URL below, so TLS is never negotiated here. A wss:// URI would therefore
-            # be silently downgraded to cleartext (verify_ssl is ignored); fail closed instead.
-            if urllib.parse.urlparse(self.url).scheme == 'wss':
+            # reserved_ports uses a raw socket and never negotiates TLS, so it only supports a
+            # plaintext ws:// URI. Require that scheme explicitly rather than, for example,
+            # connecting a wss:// URI in cleartext.
+            scheme = urllib.parse.urlparse(self.url).scheme
+            if scheme != 'ws':
                 raise ClientException(
-                    'reserved_ports connections do not support TLS; a wss:// URI cannot be used '
-                    'with reserved_ports=True (would downgrade the connection to plaintext)'
+                    f'reserved_ports connections require a ws:// URI, got {scheme!r}'
                 )
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.settimeout(10)


### PR DESCRIPTION
The reserved-port branch connects a raw socket and never negotiates TLS, so a wss:// URI connected in plaintext with verify_ssl ignored. Raise ClientException instead. This is a minor correctness change. Reserved ports are used in a specific HA internal websocket connection.

Original PR: https://github.com/truenas/api_client/pull/83
