### PR TITLE
NAS-142308 / 27.0.0-BETA.1 / Return ENOMETHOD for JSON-RPC METHOD_NOT_FOUND responses

### DIFF
--- a/truenas_api_client/__init__.py
+++ b/truenas_api_client/__init__.py
@@ -654,6 +654,8 @@ class JSONRPCClient:
         elif code == JSONRPCError.TRUENAS_CALL_ERROR:
             data = error['data']
             error = ClientException(data['reason'], data['error'], data['trace'], data['extra'])
+        elif code == JSONRPCError.METHOD_NOT_FOUND:
+            error = ClientException(error.get('message') or code.name, ErrnoMixin.ENOMETHOD)
         else:
             error = ClientException(error.get('message') or code.name)
 


### PR DESCRIPTION
A JSON-RPC `METHOD_NOT_FOUND` response reaches the caller as a `ClientException` with no errno, so consumers cannot tell a method the server does not have apart from any other failure. The legacy protocol carried this through as `ENOMETHOD`; the JSON-RPC path dropped it.

The impact is on HA. Callers of `failover.call_remote` guard on `CallError.ENOMETHOD` to degrade gracefully when the peer lacks a method, and those guards are currently unreachable because the errno arrives as `EFAULT`. The clearest case is middleware's `plugins/audit/audit.py`, which falls back to `zfs.dataset.update` when the peer predates `pool.dataset.update_impl` — that fallback never fires, so audit dataset property changes silently fail to reach an older standby during an HA upgrade. Same dead pattern in `plugins/jbof/crud.py` and the Fibre Channel remote-status helpers.

No middleware change is needed: `failover.call_remote` already prefers the exception's errno over `EFAULT`.
